### PR TITLE
fix: Cannot deploy APIs with configured HTTP headers at the endpoint …

### DIFF
--- a/src/main/java/io/gravitee/common/http/HttpHeader.java
+++ b/src/main/java/io/gravitee/common/http/HttpHeader.java
@@ -15,13 +15,14 @@
  */
 package io.gravitee.common.http;
 
+import java.io.Serializable;
 import java.util.Objects;
 
 /**
  * @author David BRASSELY (david at gravitee.io)
  * @author GraviteeSource Team
  */
-public final class HttpHeader {
+public final class HttpHeader implements Serializable {
 
     private String name;
 


### PR DESCRIPTION
…level or health check

Closes gravitee-io/issues#4963