### PR TITLE
fix: add AbtractService startup order

### DIFF
--- a/src/main/java/io/gravitee/common/service/AbstractService.java
+++ b/src/main/java/io/gravitee/common/service/AbstractService.java
@@ -46,4 +46,15 @@ public abstract class AbstractService<T extends io.gravitee.common.component.Lif
     @Override protected void doStop() throws Exception {
         LOGGER.info("Destroying service {}", name());
     }
+
+    /**
+     * Service startup order.
+     * ServiceManager will start all services plugins using this order, starting with lower ones at first.
+     * And will stop them starting with higher ones at first.
+     *
+     * @return order
+     */
+    public int getOrder() {
+        return 1000;
+    }
 }


### PR DESCRIPTION
https://github.com/gravitee-io/issues/issues/6306

add AbtractService startup order

ServiceManager will start all services plugins using this order, starting with lower ones at first.
And will stop them starting with higher ones at first.

It allows to ensure services consuming SynService events are started before he produces it.

We choose the getOrder() naming as it's already use, for example in upgraders

