### PR TITLE
feat: add vertx proxy options util

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- UUID generator -->
         <dependency>
             <groupId>com.fasterxml.uuid</groupId>

--- a/src/main/java/io/gravitee/common/util/VertxProxyOptionsUtils.java
+++ b/src/main/java/io/gravitee/common/util/VertxProxyOptionsUtils.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.util;
+
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.ProxyType;
+import java.util.Objects;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class VertxProxyOptionsUtils {
+
+    static final String PROXY_HOST_PROPERTY = "system.proxy.host";
+    static final String PROXY_PORT_PROPERTY = "system.proxy.port";
+    static final String PROXY_TYPE_PROPERTY = "system.proxy.type";
+    static final String PROXY_USERNAME_PROPERTY = "system.proxy.username";
+    static final String PROXY_PASSWORD_PROPERTY = "system.proxy.password";
+
+    public static ProxyOptions initFromSpringContext(ApplicationContext applicationContext) {
+        final Environment environment = applicationContext.getEnvironment();
+        final ProxyOptions proxyOptions = new ProxyOptions();
+        final StringBuilder errorMessageBuilder = new StringBuilder();
+
+        try {
+            proxyOptions.setHost(environment.getProperty(PROXY_HOST_PROPERTY));
+        } catch (Exception e) {
+            appendErrorMessage(errorMessageBuilder, PROXY_HOST_PROPERTY, e);
+        }
+
+        try {
+            proxyOptions.setPort(parseProxyPort(environment.getProperty(PROXY_PORT_PROPERTY)));
+        } catch (Exception e) {
+            appendErrorMessage(errorMessageBuilder, PROXY_PORT_PROPERTY, e);
+        }
+
+        try {
+            proxyOptions.setType(ProxyType.valueOf(environment.getProperty(PROXY_TYPE_PROPERTY)));
+        } catch (Exception e) {
+            appendErrorMessage(errorMessageBuilder, PROXY_TYPE_PROPERTY, e);
+        }
+
+        proxyOptions.setUsername(environment.getProperty(PROXY_USERNAME_PROPERTY));
+        proxyOptions.setPassword(environment.getProperty(PROXY_PASSWORD_PROPERTY));
+
+        if (errorMessageBuilder.length() > 0) {
+            throw new IllegalStateException(errorMessageBuilder.toString());
+        }
+
+        return proxyOptions;
+    }
+
+    private static int parseProxyPort(String proxyPortPropertyValue) {
+        return Integer.parseInt(Objects.requireNonNull(proxyPortPropertyValue, "Proxy port may not be null"));
+    }
+
+    private static void appendErrorMessage(StringBuilder messageBuilder, String property, Exception e) {
+        if (messageBuilder.length() > 0) {
+            messageBuilder.append(", ");
+        }
+        messageBuilder.append(property).append(": ").append(e.getMessage());
+    }
+}

--- a/src/test/java/io/gravitee/common/util/VertxProxyOptionsUtilsTest.java
+++ b/src/test/java/io/gravitee/common/util/VertxProxyOptionsUtilsTest.java
@@ -1,0 +1,196 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.util;
+
+import static io.gravitee.common.util.VertxProxyOptionsUtils.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.net.ProxyOptions;
+import io.vertx.core.net.ProxyType;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class VertxProxyOptionsUtilsTest {
+
+    @Test
+    void shouldCreateProxyOptions() {
+        final Environment environment = mock(Environment.class);
+        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("3128");
+        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        final ProxyOptions expectedProxyOptions = new ProxyOptions();
+
+        ProxyOptions proxyOptions = initFromSpringContext(springContext);
+
+        assertThat(proxyOptions).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
+    }
+
+    @Test
+    void shouldCreateProxyOptionsWithUserNameAndPassword() {
+        final Environment environment = mock(Environment.class);
+        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("3128");
+        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
+        when(environment.getProperty(PROXY_USERNAME_PROPERTY)).thenReturn("gravitee");
+        when(environment.getProperty(PROXY_PASSWORD_PROPERTY)).thenReturn("gravitee");
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        final ProxyOptions expectedProxyOptions = new ProxyOptions();
+        expectedProxyOptions.setUsername("gravitee");
+        expectedProxyOptions.setPassword("gravitee");
+
+        ProxyOptions proxyOptions = initFromSpringContext(springContext);
+
+        assertThat(proxyOptions).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
+    }
+
+    @Test
+    void shouldSupportSocks4() {
+        final Environment environment = mock(Environment.class);
+        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("4145");
+        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("SOCKS4");
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        final ProxyOptions expectedProxyOptions = new ProxyOptions();
+        expectedProxyOptions.setPort(4145);
+        expectedProxyOptions.setType(ProxyType.SOCKS4);
+
+        ProxyOptions proxyOptions = initFromSpringContext(springContext);
+
+        assertThat(proxyOptions).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
+    }
+
+    @Test
+    void shouldSupportSocks5() {
+        final Environment environment = mock(Environment.class);
+        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("1080");
+        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("SOCKS5");
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        final ProxyOptions expectedProxyOptions = new ProxyOptions();
+        expectedProxyOptions.setPort(1080);
+        expectedProxyOptions.setType(ProxyType.SOCKS5);
+
+        ProxyOptions proxyOptions = initFromSpringContext(springContext);
+
+        assertThat(proxyOptions).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
+    }
+
+    @Test
+    void shouldNotCreateProxyOptionsBecauseNoHost() {
+        final Environment environment = mock(Environment.class);
+        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("4145");
+        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("SOCKS4");
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        assertThatThrownBy(() -> initFromSpringContext(springContext))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("system.proxy.host: Proxy host may not be null");
+    }
+
+    @Test
+    void shouldNotCreateProxyOptionsBecauseNoPort() {
+        final Environment environment = mock(Environment.class);
+        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        assertThatThrownBy(() -> initFromSpringContext(springContext))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("system.proxy.port: Proxy port may not be null");
+    }
+
+    @Test
+    void shouldNotCreateProxyOptionsBecausePortIsNotANumber() {
+        final Environment environment = mock(Environment.class);
+        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("1O24");
+        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        assertThatThrownBy(() -> initFromSpringContext(springContext))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("system.proxy.port: For input string: \"1O24\"");
+    }
+
+    @Test
+    void shouldNotCreateProxyOptionsBecausePortIsOutOfRange() {
+        final Environment environment = mock(Environment.class);
+        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("65536");
+        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        assertThatThrownBy(() -> initFromSpringContext(springContext))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("system.proxy.port: Invalid proxy port 65536");
+    }
+
+    @Test
+    void shouldNotCreateProxyOptionsBecauseOfUnknownType() {
+        final Environment environment = mock(Environment.class);
+        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("70");
+        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("GOPHER");
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        assertThatThrownBy(() -> initFromSpringContext(springContext))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("system.proxy.type: No enum constant io.vertx.core.net.ProxyType.GOPHER");
+    }
+
+    @Test
+    void shouldAggregateErrorMessages() {
+        final Environment environment = mock(Environment.class);
+
+        final ApplicationContext springContext = mock(ApplicationContext.class);
+        when(springContext.getEnvironment()).thenReturn(environment);
+
+        assertThatThrownBy(() -> initFromSpringContext(springContext))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining(
+                "system.proxy.host: Proxy host may not be null, system.proxy.port: Proxy port may not be null, system.proxy.type: Name is null"
+            );
+    }
+}


### PR DESCRIPTION
Add vertx proxy option util to initialise system proxy options from a
spring environment for further reuse in classes that implement the
use system proxy feature.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.26.0-feat-add-proxy-options-util-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/1.26.0-feat-add-proxy-options-util-SNAPSHOT/gravitee-common-1.26.0-feat-add-proxy-options-util-SNAPSHOT.zip)
  <!-- Version placeholder end -->
