### PR TITLE
fix: init vertx proxy options from node configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <properties>
         <gravitee-bom.version>1.4</gravitee-bom.version>
+        <gravitee-node.version>1.20.3</gravitee-node.version>
         <java-uuid-generator.version>3.1.4</java-uuid-generator.version>
         <bouncycastle.version>1.69</bouncycastle.version>
     </properties>
@@ -54,6 +55,13 @@
 
     <dependencies>
         <!-- Logging -->
+        <dependency>
+            <groupId>io.gravitee.node</groupId>
+            <artifactId>gravitee-node-api</artifactId>
+            <version>${gravitee-node.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/src/main/java/io/gravitee/common/util/VertxProxyOptionsUtils.java
+++ b/src/main/java/io/gravitee/common/util/VertxProxyOptionsUtils.java
@@ -15,11 +15,11 @@
  */
 package io.gravitee.common.util;
 
+import io.gravitee.node.api.configuration.Configuration;
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import java.util.Objects;
-import org.springframework.context.ApplicationContext;
-import org.springframework.core.env.Environment;
 
 /**
  * @author GraviteeSource Team
@@ -32,31 +32,34 @@ public class VertxProxyOptionsUtils {
     static final String PROXY_USERNAME_PROPERTY = "system.proxy.username";
     static final String PROXY_PASSWORD_PROPERTY = "system.proxy.password";
 
-    public static ProxyOptions initFromSpringContext(ApplicationContext applicationContext) {
-        final Environment environment = applicationContext.getEnvironment();
+    public static void setSystemProxy(HttpClientOptions options, Configuration configuration) {
+        options.setProxyOptions(buildProxyOptions(configuration));
+    }
+
+    public static ProxyOptions buildProxyOptions(Configuration configuration) {
         final ProxyOptions proxyOptions = new ProxyOptions();
         final StringBuilder errorMessageBuilder = new StringBuilder();
 
         try {
-            proxyOptions.setHost(environment.getProperty(PROXY_HOST_PROPERTY));
+            proxyOptions.setHost(configuration.getProperty(PROXY_HOST_PROPERTY));
         } catch (Exception e) {
             appendErrorMessage(errorMessageBuilder, PROXY_HOST_PROPERTY, e);
         }
 
         try {
-            proxyOptions.setPort(parseProxyPort(environment.getProperty(PROXY_PORT_PROPERTY)));
+            proxyOptions.setPort(parseProxyPort(configuration.getProperty(PROXY_PORT_PROPERTY)));
         } catch (Exception e) {
             appendErrorMessage(errorMessageBuilder, PROXY_PORT_PROPERTY, e);
         }
 
         try {
-            proxyOptions.setType(ProxyType.valueOf(environment.getProperty(PROXY_TYPE_PROPERTY)));
+            proxyOptions.setType(ProxyType.valueOf(configuration.getProperty(PROXY_TYPE_PROPERTY)));
         } catch (Exception e) {
             appendErrorMessage(errorMessageBuilder, PROXY_TYPE_PROPERTY, e);
         }
 
-        proxyOptions.setUsername(environment.getProperty(PROXY_USERNAME_PROPERTY));
-        proxyOptions.setPassword(environment.getProperty(PROXY_PASSWORD_PROPERTY));
+        proxyOptions.setUsername(configuration.getProperty(PROXY_USERNAME_PROPERTY));
+        proxyOptions.setPassword(configuration.getProperty(PROXY_PASSWORD_PROPERTY));
 
         if (errorMessageBuilder.length() > 0) {
             throw new IllegalStateException(errorMessageBuilder.toString());

--- a/src/test/java/io/gravitee/common/util/VertxProxyOptionsUtilsTest.java
+++ b/src/test/java/io/gravitee/common/util/VertxProxyOptionsUtilsTest.java
@@ -20,11 +20,11 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.gravitee.node.api.configuration.Configuration;
+import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.net.ProxyOptions;
 import io.vertx.core.net.ProxyType;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.ApplicationContext;
-import org.springframework.core.env.Environment;
 
 /**
  * @author GraviteeSource Team
@@ -32,162 +32,140 @@ import org.springframework.core.env.Environment;
 public class VertxProxyOptionsUtilsTest {
 
     @Test
-    void shouldCreateProxyOptions() {
-        final Environment environment = mock(Environment.class);
-        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
-        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("3128");
-        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
-
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
+    void shouldCreateFromProperties() {
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(configuration.getProperty(PROXY_PORT_PROPERTY)).thenReturn("3128");
+        when(configuration.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
 
         final ProxyOptions expectedProxyOptions = new ProxyOptions();
 
-        ProxyOptions proxyOptions = initFromSpringContext(springContext);
+        final HttpClientOptions httpClientOptions = new HttpClientOptions();
 
-        assertThat(proxyOptions).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
+        setSystemProxy(httpClientOptions, configuration);
+
+        assertThat(httpClientOptions.getProxyOptions()).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
     }
 
     @Test
     void shouldCreateProxyOptionsWithUserNameAndPassword() {
-        final Environment environment = mock(Environment.class);
-        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
-        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("3128");
-        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
-        when(environment.getProperty(PROXY_USERNAME_PROPERTY)).thenReturn("gravitee");
-        when(environment.getProperty(PROXY_PASSWORD_PROPERTY)).thenReturn("gravitee");
-
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(configuration.getProperty(PROXY_PORT_PROPERTY)).thenReturn("3128");
+        when(configuration.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
+        when(configuration.getProperty(PROXY_USERNAME_PROPERTY)).thenReturn("gravitee");
+        when(configuration.getProperty(PROXY_PASSWORD_PROPERTY)).thenReturn("gravitee");
 
         final ProxyOptions expectedProxyOptions = new ProxyOptions();
         expectedProxyOptions.setUsername("gravitee");
         expectedProxyOptions.setPassword("gravitee");
 
-        ProxyOptions proxyOptions = initFromSpringContext(springContext);
+        final HttpClientOptions httpClientOptions = new HttpClientOptions();
 
-        assertThat(proxyOptions).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
+        setSystemProxy(httpClientOptions, configuration);
+
+        assertThat(httpClientOptions.getProxyOptions()).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
     }
 
     @Test
     void shouldSupportSocks4() {
-        final Environment environment = mock(Environment.class);
-        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
-        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("4145");
-        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("SOCKS4");
-
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(configuration.getProperty(PROXY_PORT_PROPERTY)).thenReturn("4145");
+        when(configuration.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("SOCKS4");
 
         final ProxyOptions expectedProxyOptions = new ProxyOptions();
         expectedProxyOptions.setPort(4145);
         expectedProxyOptions.setType(ProxyType.SOCKS4);
 
-        ProxyOptions proxyOptions = initFromSpringContext(springContext);
+        final HttpClientOptions httpClientOptions = new HttpClientOptions();
 
-        assertThat(proxyOptions).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
+        setSystemProxy(httpClientOptions, configuration);
+
+        assertThat(httpClientOptions.getProxyOptions()).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
     }
 
     @Test
     void shouldSupportSocks5() {
-        final Environment environment = mock(Environment.class);
-        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
-        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("1080");
-        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("SOCKS5");
-
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(configuration.getProperty(PROXY_PORT_PROPERTY)).thenReturn("1080");
+        when(configuration.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("SOCKS5");
 
         final ProxyOptions expectedProxyOptions = new ProxyOptions();
         expectedProxyOptions.setPort(1080);
         expectedProxyOptions.setType(ProxyType.SOCKS5);
 
-        ProxyOptions proxyOptions = initFromSpringContext(springContext);
+        final HttpClientOptions httpClientOptions = new HttpClientOptions();
 
-        assertThat(proxyOptions).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
+        setSystemProxy(httpClientOptions, configuration);
+
+        assertThat(httpClientOptions.getProxyOptions()).usingRecursiveComparison().isEqualTo(expectedProxyOptions);
     }
 
     @Test
     void shouldNotCreateProxyOptionsBecauseNoHost() {
-        final Environment environment = mock(Environment.class);
-        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("4145");
-        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("SOCKS4");
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(PROXY_PORT_PROPERTY)).thenReturn("4145");
+        when(configuration.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("SOCKS4");
 
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
-
-        assertThatThrownBy(() -> initFromSpringContext(springContext))
+        assertThatThrownBy(() -> setSystemProxy(new HttpClientOptions(), configuration))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("system.proxy.host: Proxy host may not be null");
     }
 
     @Test
     void shouldNotCreateProxyOptionsBecauseNoPort() {
-        final Environment environment = mock(Environment.class);
-        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
-        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(configuration.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
 
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
-
-        assertThatThrownBy(() -> initFromSpringContext(springContext))
+        assertThatThrownBy(() -> setSystemProxy(new HttpClientOptions(), configuration))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("system.proxy.port: Proxy port may not be null");
     }
 
     @Test
     void shouldNotCreateProxyOptionsBecausePortIsNotANumber() {
-        final Environment environment = mock(Environment.class);
-        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
-        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("1O24");
-        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(configuration.getProperty(PROXY_PORT_PROPERTY)).thenReturn("1O24");
+        when(configuration.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
 
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
-
-        assertThatThrownBy(() -> initFromSpringContext(springContext))
+        assertThatThrownBy(() -> setSystemProxy(new HttpClientOptions(), configuration))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("system.proxy.port: For input string: \"1O24\"");
     }
 
     @Test
     void shouldNotCreateProxyOptionsBecausePortIsOutOfRange() {
-        final Environment environment = mock(Environment.class);
-        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
-        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("65536");
-        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(configuration.getProperty(PROXY_PORT_PROPERTY)).thenReturn("65536");
+        when(configuration.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("HTTP");
 
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
-
-        assertThatThrownBy(() -> initFromSpringContext(springContext))
+        assertThatThrownBy(() -> setSystemProxy(new HttpClientOptions(), configuration))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("system.proxy.port: Invalid proxy port 65536");
     }
 
     @Test
     void shouldNotCreateProxyOptionsBecauseOfUnknownType() {
-        final Environment environment = mock(Environment.class);
-        when(environment.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
-        when(environment.getProperty(PROXY_PORT_PROPERTY)).thenReturn("70");
-        when(environment.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("GOPHER");
+        final Configuration configuration = mock(Configuration.class);
+        when(configuration.getProperty(PROXY_HOST_PROPERTY)).thenReturn("localhost");
+        when(configuration.getProperty(PROXY_PORT_PROPERTY)).thenReturn("70");
+        when(configuration.getProperty(PROXY_TYPE_PROPERTY)).thenReturn("GOPHER");
 
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
-
-        assertThatThrownBy(() -> initFromSpringContext(springContext))
+        assertThatThrownBy(() -> setSystemProxy(new HttpClientOptions(), configuration))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining("system.proxy.type: No enum constant io.vertx.core.net.ProxyType.GOPHER");
     }
 
     @Test
     void shouldAggregateErrorMessages() {
-        final Environment environment = mock(Environment.class);
+        final Configuration configuration = mock(Configuration.class);
 
-        final ApplicationContext springContext = mock(ApplicationContext.class);
-        when(springContext.getEnvironment()).thenReturn(environment);
-
-        assertThatThrownBy(() -> initFromSpringContext(springContext))
+        assertThatThrownBy(() -> setSystemProxy(new HttpClientOptions(), configuration))
             .isInstanceOf(IllegalStateException.class)
             .hasMessageContaining(
                 "system.proxy.host: Proxy host may not be null, system.proxy.port: Proxy port may not be null, system.proxy.type: Name is null"


### PR DESCRIPTION
Because environment is not always accessed from spring application context,
we need a way to build the vertx proxy options from other sources.

To answer that need, Vertx proxy options are created from the gravitee node `Configuration` interface.

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.26.1-fix-vertx-proxy-options-utils-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/1.26.1-fix-vertx-proxy-options-utils-SNAPSHOT/gravitee-common-1.26.1-fix-vertx-proxy-options-utils-SNAPSHOT.zip)
  <!-- Version placeholder end -->
