### PR TITLE
Bump rx java

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_lib-release-config:
@@ -32,4 +32,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
 
     <groupId>io.gravitee.common</groupId>
     <artifactId>gravitee-common</artifactId>
-    <version>1.28.0</version>
+    <version>2.0.0-alpha.1</version>
 
     <name>Gravitee.io APIM - Common</name>
 
     <properties>
-        <gravitee-bom.version>2.5</gravitee-bom.version>
-        <gravitee-node.version>1.20.3</gravitee-node.version>
+        <gravitee-bom.version>2.7</gravitee-bom.version>
+        <gravitee-node.version>2.0.0-alpha.3</gravitee-node.version>
         <java-uuid-generator.version>3.1.4</java-uuid-generator.version>
         <bouncycastle.version>1.69</bouncycastle.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>

--- a/src/main/java/io/gravitee/common/utils/RxHelper.java
+++ b/src/main/java/io/gravitee/common/utils/RxHelper.java
@@ -15,8 +15,8 @@
  */
 package io.gravitee.common.utils;
 
-import io.reactivex.Flowable;
-import io.reactivex.FlowableTransformer;
+import io.reactivex.rxjava3.core.Flowable;
+import io.reactivex.rxjava3.core.FlowableTransformer;
 import org.reactivestreams.Publisher;
 
 /**
@@ -27,7 +27,7 @@ public class RxHelper {
 
     /**
      * Returns a {@link FlowableTransformer} that can be used in a composition.
-     * It basically offers the same behavior as {@link io.reactivex.Flowable#mergeWith(Publisher)} but allows completing as soon as one of the sources completes (success, error or disposed).
+     * It basically offers the same behavior as {@link io.reactivex.rxjava3.core.Flowable#mergeWith(Publisher)} but allows completing as soon as one of the sources completes (success, error or disposed).
      *
      * @param other the other source.
      * @param <R> the type of the items emitted.

--- a/src/test/java/io/gravitee/common/utils/RxHelperTest.java
+++ b/src/test/java/io/gravitee/common/utils/RxHelperTest.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.common.utils;
 
-import io.reactivex.Flowable;
+import io.reactivex.rxjava3.core.Flowable;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7990
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-bumpRxJava-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/2.0.0-bumpRxJava-SNAPSHOT/gravitee-common-2.0.0-bumpRxJava-SNAPSHOT.zip)
  <!-- Version placeholder end -->
