### PR TITLE
fix: use passwordToCharArray to properly handle password

### DIFF
--- a/src/main/java/io/gravitee/common/util/KeyStoreUtils.java
+++ b/src/main/java/io/gravitee/common/util/KeyStoreUtils.java
@@ -72,7 +72,7 @@ public class KeyStoreUtils {
     public static KeyStore initFromPath(String format, String path, String password) {
         try (InputStream is = new File(path).toURI().toURL().openStream()) {
             final KeyStore keyStore = KeyStore.getInstance(format);
-            keyStore.load(is, null == password ? null : password.toCharArray());
+            keyStore.load(is, passwordToCharArray(password));
             return keyStore;
         } catch (Exception e) {
             throw new IllegalArgumentException(String.format("Unable to load keystore from path [%s]", path), e);
@@ -92,7 +92,7 @@ public class KeyStoreUtils {
         try {
             final ByteArrayInputStream stream = new ByteArrayInputStream(Base64.getDecoder().decode(keystore));
             KeyStore keyStore = KeyStore.getInstance(format);
-            keyStore.load(stream, password.toCharArray());
+            keyStore.load(stream, passwordToCharArray(password));
             return keyStore;
         } catch (Exception e) {
             throw new IllegalArgumentException("Unable to get keystore from base64", e);
@@ -140,7 +140,7 @@ public class KeyStoreUtils {
             keyStore.setEntry(
                 DEFAULT_ALIAS,
                 new KeyStore.PrivateKeyEntry(privateKey, new Certificate[] { certificate }),
-                new KeyStore.PasswordProtection(password.toCharArray())
+                new KeyStore.PasswordProtection(passwordToCharArray(password))
             );
 
             return keyStore;


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/APIM-200

**Description**

Use  `passwordToCharArray` everywhere it is required

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-apim-200-mqtt5-security-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/2.0.0-apim-200-mqtt5-security-SNAPSHOT/gravitee-common-2.0.0-apim-200-mqtt5-security-SNAPSHOT.zip)
  <!-- Version placeholder end -->
