### PR TITLE
feat: add rx helpers method to retry a flowable with delay between at…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <java-uuid-generator.version>3.1.4</java-uuid-generator.version>
         <bouncycastle.version>1.69</bouncycastle.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
+        <lombok.version>1.18.24</lombok.version>
     </properties>
 
     <dependencyManagement>
@@ -106,6 +107,13 @@
             <artifactId>nimbus-jose-jwt</artifactId>
             <version>${nimbus-jose-jwt.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
         </dependency>
 
         <!-- Unit Tests -->


### PR DESCRIPTION
**Issue**

https://graviteecommunity.atlassian.net/browse/APIM-141

**Description**

Add methods to RxHelper:
- `delayElement`: apply a delay for each element received in the upstream
- `retry` (on Completable) and `retryFlowable` which retry the upstream with delay between timer and til a maxAttempt limit.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-apim-141-manageV4subscriptions-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/2.0.0-apim-141-manageV4subscriptions-SNAPSHOT/gravitee-common-2.0.0-apim-141-manageV4subscriptions-SNAPSHOT.zip)
  <!-- Version placeholder end -->
