### PR TITLE
feat: add uri isAbsolute util function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.common</groupId>
     <artifactId>gravitee-common</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-apim-455-user-defined-endpoint-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Common</name>
 

--- a/src/main/java/io/gravitee/common/util/URIUtils.java
+++ b/src/main/java/io/gravitee/common/util/URIUtils.java
@@ -15,17 +15,41 @@
  */
 package io.gravitee.common.util;
 
+import java.util.regex.Pattern;
+
 /**
  * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class URIUtils {
 
+    private static final Pattern URL_PATTERN = Pattern.compile("^\\w{2,}://.*$");
     private static final char FRAGMENT_SEPARATOR_CHAR = '#';
     private static final char QUERYPARAM_SEPARATOR_CHAR1 = '&';
     private static final char QUERYPARAM_SEPARATOR_CHAR2 = ';';
     private static final char QUERYPARAM_VALUE_SEPARATOR_CHAR = '=';
     private static final char QUERY_SEPARATOR_CHAR = '?';
+
+    /**
+     * An url is considered absolute if it starts with <code>protocol://</code>.
+     * Protocol must at least contain 2 chars, ex:
+     * <ul>
+     *     <li>https://api.gravitee.io/echo: is absolute</li>
+     *     <li>http://api.gravitee.io/echo: is absolute</li>
+     *     <li>wss://api.gravitee.io/echo: is absolute</li>
+     *     <li>kafka://kafka.gravitee.io: is absolute</li>
+     *     <li>a://kafka.gravitee.io: is not considered as absolute cause the protocol isn't valid ( < 2 chars)</li>
+     *     <li>/echo: is not absolute</li>
+     *     <li>?foo=bar: is not absolute</li>
+     *     <li><i>empty</i>: is not absolute</li>
+     * </ul>
+     *
+     * @param uri the uri to test.
+     * @return <code>true</code> if the uri is considered absolute, <code>false</code> otherwise.
+     */
+    public static boolean isAbsolute(final String uri) {
+        return uri != null && URL_PATTERN.matcher(uri).matches();
+    }
 
     public static MultiValueMap<String, String> parameters(String uri) {
         MultiValueMap<String, String> queryParameters;

--- a/src/test/java/io/gravitee/common/util/URIUtilsTest.java
+++ b/src/test/java/io/gravitee/common/util/URIUtilsTest.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.common.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class URIUtilsTest {
 
@@ -142,7 +146,7 @@ public class URIUtilsTest {
     public void test17() {
         MultiValueMap<String, String> parameters = URIUtils.parameters("?k");
         Assertions.assertEquals(1, parameters.size());
-        Assertions.assertEquals(null, parameters.get("k").get(0));
+        Assertions.assertNull(parameters.get("k").get(0));
     }
 
     @Test
@@ -150,9 +154,9 @@ public class URIUtilsTest {
         MultiValueMap<String, String> parameters = URIUtils.parameters("?k&j");
         Assertions.assertEquals(2, parameters.size());
         Assertions.assertTrue(parameters.containsKey("k"));
-        Assertions.assertEquals(null, parameters.get("k").get(0));
+        Assertions.assertNull(parameters.get("k").get(0));
         Assertions.assertTrue(parameters.containsKey("j"));
-        Assertions.assertEquals(null, parameters.get("j").get(0));
+        Assertions.assertNull(parameters.get("j").get(0));
     }
 
     @Test
@@ -160,7 +164,7 @@ public class URIUtilsTest {
         MultiValueMap<String, String> parameters = URIUtils.parameters("?foo=bar&k");
         Assertions.assertEquals(2, parameters.size());
         Assertions.assertTrue(parameters.containsKey("k"));
-        Assertions.assertEquals(null, parameters.get("k").get(0));
+        Assertions.assertNull(parameters.get("k").get(0));
         Assertions.assertTrue(parameters.containsKey("foo"));
         Assertions.assertEquals("bar", parameters.get("foo").get(0));
     }
@@ -170,7 +174,7 @@ public class URIUtilsTest {
         MultiValueMap<String, String> parameters = URIUtils.parameters("?k&foo=bar");
         Assertions.assertEquals(2, parameters.size());
         Assertions.assertTrue(parameters.containsKey("k"));
-        Assertions.assertEquals(null, parameters.get("k").get(0));
+        Assertions.assertNull(parameters.get("k").get(0));
         Assertions.assertTrue(parameters.containsKey("foo"));
         Assertions.assertEquals("bar", parameters.get("foo").get(0));
     }
@@ -180,7 +184,7 @@ public class URIUtilsTest {
         MultiValueMap<String, String> parameters = URIUtils.parameters("?foo1=bar&k&foo=bar");
         Assertions.assertEquals(3, parameters.size());
         Assertions.assertTrue(parameters.containsKey("k"));
-        Assertions.assertEquals(null, parameters.get("k").get(0));
+        Assertions.assertNull(parameters.get("k").get(0));
         Assertions.assertTrue(parameters.containsKey("foo"));
         Assertions.assertEquals("bar", parameters.get("foo").get(0));
         Assertions.assertTrue(parameters.containsKey("foo1"));
@@ -192,10 +196,27 @@ public class URIUtilsTest {
         MultiValueMap<String, String> parameters = URIUtils.parameters("?foo1&k=v&foo");
         Assertions.assertEquals(3, parameters.size());
         Assertions.assertTrue(parameters.containsKey("foo1"));
-        Assertions.assertEquals(null, parameters.get("foo1").get(0));
+        Assertions.assertNull(parameters.get("foo1").get(0));
         Assertions.assertTrue(parameters.containsKey("foo"));
-        Assertions.assertEquals(null, parameters.get("foo").get(0));
+        Assertions.assertNull(parameters.get("foo").get(0));
         Assertions.assertTrue(parameters.containsKey("k"));
         Assertions.assertEquals("v", parameters.get("k").get(0));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "http://api.gravitee.io/echo", "https://api.gravitee.io/echo", "any://api.gravitee.io/echo" })
+    public void shouldBeAbsolute(String url) {
+        assertThat(URIUtils.isAbsolute(url)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "a://api.gravitee.io/echo", "api.gravitee.io/echo", "/echo" })
+    public void shouldNotBeAbsolute() {
+        assertThat(URIUtils.isAbsolute("a://api.gravitee.io/echo")).isFalse();
+    }
+
+    @Test
+    public void shouldNotBeAbsoluteWithNull() {
+        assertThat(URIUtils.isAbsolute(null)).isFalse();
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-455

**Description**

Add an util function to quickly check if a url is absolute or not.

[APIM-455]: https://gravitee.atlassian.net/browse/APIM-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-apim-455-user-defined-endpoint-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/2.1.0-apim-455-user-defined-endpoint-SNAPSHOT/gravitee-common-2.1.0-apim-455-user-defined-endpoint-SNAPSHOT.zip)
  <!-- Version placeholder end -->
