### PR TITLE
fix: remove the use of Spring framework

### DIFF
--- a/src/main/java/io/gravitee/common/utils/DurationParser.java
+++ b/src/main/java/io/gravitee/common/utils/DurationParser.java
@@ -51,7 +51,7 @@ public class DurationParser {
      */
     public static Duration parse(final String value) {
         Duration duration = null;
-        if (StringUtils.hasLength(value)) {
+        if (value != null && value.length() > 0) {
             try {
                 duration = Duration.parse(value);
             } catch (DateTimeParseException e) {


### PR DESCRIPTION
Remove the usage of spring framework for DurationParser.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-fix-duration-parser-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/2.1.0-fix-duration-parser-SNAPSHOT/gravitee-common-2.1.0-fix-duration-parser-SNAPSHOT.zip)
  <!-- Version placeholder end -->
