### PR TITLE
feat: parse semicolon as a normal char for query parameters

### DIFF
--- a/src/main/java/io/gravitee/common/util/URIUtils.java
+++ b/src/main/java/io/gravitee/common/util/URIUtils.java
@@ -51,7 +51,23 @@ public class URIUtils {
         return uri != null && URL_PATTERN.matcher(uri).matches();
     }
 
+    /**
+     * Splits an HTTP query string into key-multivalues parameters pairs.
+     * @param uri to splits to extract query parameters
+     * @return a {@link MultiValueMap<String, String>} of query parameters
+     */
     public static MultiValueMap<String, String> parameters(String uri) {
+        return parameters(uri, false);
+    }
+
+    /**
+     * Splits an HTTP query string into key-multivalues parameters pairs.
+     * Can be used considering semicolon char ";" as a separator or as a normal char (useful for url-encoded-form-data or OData queries).
+     * @param uri to splits to extract query parameters
+     * @param semicolonIsNormalChar, when true, uses netty's QueryStringDecoder to consider semicolon character as a normal one
+     * @return a {@link MultiValueMap<String, String>} of query parameters
+     */
+    public static MultiValueMap<String, String> parameters(String uri, boolean semicolonIsNormalChar) {
         MultiValueMap<String, String> queryParameters;
         int questionMarkIndex = uri.indexOf(QUERY_SEPARATOR_CHAR);
         if (questionMarkIndex < 0 || uri.length() == (questionMarkIndex + 1)) {
@@ -71,8 +87,11 @@ public class URIUtils {
                             paramValueStart = i + 1;
                         }
                         break;
-                    case QUERYPARAM_SEPARATOR_CHAR1:
                     case QUERYPARAM_SEPARATOR_CHAR2:
+                        if (semicolonIsNormalChar) {
+                            continue;
+                        }
+                    case QUERYPARAM_SEPARATOR_CHAR1:
                         addParameter(queryParameters, uri, paramNameStart, paramValueStart, i);
                         paramNameStart = i + 1;
                         break;

--- a/src/test/java/io/gravitee/common/util/URIUtilsTest.java
+++ b/src/test/java/io/gravitee/common/util/URIUtilsTest.java
@@ -17,206 +17,141 @@ package io.gravitee.common.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Assertions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 public class URIUtilsTest {
 
-    @Test
-    public void test1() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=v");
-        Assertions.assertEquals("v", parameters.get("k").get(0));
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class QueryParameters {
+
+        @ParameterizedTest
+        @MethodSource("provideParametersWithSemicolonAsSeparator")
+        void should_test_query_parameters_semicolon_as_separator(String query, MultiValueMap<String, String> expectedQueryParameters) {
+            final MultiValueMap<String, String> result = URIUtils.parameters(query);
+            assertThat(result).isEqualTo(URIUtils.parameters(query, false)).isEqualTo(expectedQueryParameters);
+        }
+
+        @ParameterizedTest
+        @MethodSource("provideParametersWithSemicolonAsNormalChar")
+        void should_test_query_parameters_semicolon_as_normal_char(String query, MultiValueMap<String, String> expectedQueryParameters) {
+            final MultiValueMap<String, String> result = URIUtils.parameters(query, true);
+            assertThat(result).isEqualTo(expectedQueryParameters);
+        }
+
+        Stream<Arguments> provideParametersWithSemicolonAsSeparator() {
+            return provideParameters(false);
+        }
+
+        Stream<Arguments> provideParametersWithSemicolonAsNormalChar() {
+            return provideParameters(true);
+        }
+
+        Stream<Arguments> provideParameters(boolean semicolonAsNormalChar) {
+            return Stream.of(
+                Arguments.of("", new LinkedMultiValueMap<>()),
+                Arguments.of("?", new LinkedMultiValueMap<>()),
+                Arguments.of("?k", new LinkedMultiValueMap<>(Map.of("k", listOfNull()))),
+                Arguments.of("?k&j", new LinkedMultiValueMap<>(Map.of("k", listOfNull(), "j", listOfNull()))),
+                Arguments.of("?foo=bar&k", new LinkedMultiValueMap<>(Map.of("foo", List.of("bar"), "k", listOfNull()))),
+                Arguments.of("?k&foo=bar", new LinkedMultiValueMap<>(Map.of("foo", List.of("bar"), "k", listOfNull()))),
+                Arguments.of(
+                    "?foo1=bar&k&foo=bar",
+                    new LinkedMultiValueMap<>(Map.of("foo", List.of("bar"), "foo1", List.of("bar"), "k", listOfNull()))
+                ),
+                Arguments.of(
+                    "?foo1&k=v&foo",
+                    new LinkedMultiValueMap<>(Map.of("foo", listOfNull(), "k", List.of("v"), "foo1", listOfNull()))
+                ),
+                Arguments.of("?filter=", new LinkedMultiValueMap<>(Map.of("filter", List.of("")))),
+                Arguments.of("?filter=field1", new LinkedMultiValueMap<>(Map.of("filter", List.of("field1")))),
+                Arguments.of("/test?filter=field1", new LinkedMultiValueMap<>(Map.of("filter", List.of("field1")))),
+                Arguments.of("/test?filter==field1", new LinkedMultiValueMap<>(Map.of("filter", List.of("=field1")))),
+                Arguments.of("/test?filter=%3field1", new LinkedMultiValueMap<>(Map.of("filter", List.of("%3field1")))),
+                Arguments.of("/test?filter=%20field1", new LinkedMultiValueMap<>(Map.of("filter", List.of("%20field1")))),
+                Arguments.of("/test?filter=field1#123", new LinkedMultiValueMap<>(Map.of("filter", List.of("field1")))),
+                Arguments.of(
+                    "/test?filter=field1&date=yesterday",
+                    new LinkedMultiValueMap<>(Map.of("filter", List.of("field1"), "date", List.of("yesterday")))
+                ),
+                Arguments.of(
+                    "/test?filter=field1;date=yesterday",
+                    semicolonAsNormalChar
+                        ? new LinkedMultiValueMap<>(Map.of("filter", List.of("field1;date=yesterday")))
+                        : new LinkedMultiValueMap<>(Map.of("filter", List.of("field1"), "date", List.of("yesterday")))
+                ),
+                Arguments.of(
+                    "/test?filter=;date=yesterday",
+                    semicolonAsNormalChar
+                        ? new LinkedMultiValueMap<>(Map.of("filter", List.of(";date=yesterday")))
+                        : new LinkedMultiValueMap<>(Map.of("filter", List.of(""), "date", List.of("yesterday")))
+                ),
+                Arguments.of(
+                    "/test?filter=field1;date=yesterday&foo=bar",
+                    semicolonAsNormalChar
+                        ? new LinkedMultiValueMap<>(Map.of("filter", List.of("field1;date=yesterday"), "foo", List.of("bar")))
+                        : new LinkedMultiValueMap<>(
+                            Map.of("filter", List.of("field1"), "date", List.of("yesterday"), "foo", List.of("bar"))
+                        )
+                ),
+                Arguments.of(
+                    "/test?filter=field1;date=yesterday&foo=bar&",
+                    semicolonAsNormalChar
+                        ? new LinkedMultiValueMap<>(Map.of("filter", List.of("field1;date=yesterday"), "foo", List.of("bar")))
+                        : new LinkedMultiValueMap<>(
+                            Map.of("filter", List.of("field1"), "date", List.of("yesterday"), "foo", List.of("bar"))
+                        )
+                ),
+                Arguments.of(
+                    "/test?filter=field1;date=yesterday&foo=bar;",
+                    semicolonAsNormalChar
+                        ? new LinkedMultiValueMap<>(Map.of("filter", List.of("field1;date=yesterday"), "foo", List.of("bar;")))
+                        : new LinkedMultiValueMap<>(
+                            Map.of("filter", List.of("field1"), "date", List.of("yesterday"), "foo", List.of("bar"))
+                        )
+                ),
+                Arguments.of("?filter=field1&filter=field2", new LinkedMultiValueMap<>(Map.of("filter", List.of("field1", "field2"))))
+            );
+        }
+
+        private List<String> listOfNull() {
+            final ArrayList<String> list = new ArrayList<>();
+            list.add(null);
+            return list;
+        }
     }
 
-    @Test
-    public void test2() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("?k=v");
-        Assertions.assertEquals("v", parameters.get("k").get(0));
-    }
+    @Nested
+    class IsAbsolute {
 
-    @Test
-    public void test3() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("");
-        Assertions.assertEquals(0, parameters.size());
-    }
+        @ParameterizedTest
+        @ValueSource(strings = { "http://api.gravitee.io/echo", "https://api.gravitee.io/echo", "any://api.gravitee.io/echo" })
+        public void shouldBeAbsolute(String url) {
+            assertThat(URIUtils.isAbsolute(url)).isTrue();
+        }
 
-    @Test
-    public void test4() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("?");
-        Assertions.assertEquals(0, parameters.size());
-    }
+        @ParameterizedTest
+        @ValueSource(strings = { "a://api.gravitee.io/echo", "api.gravitee.io/echo", "/echo" })
+        public void shouldNotBeAbsolute() {
+            assertThat(URIUtils.isAbsolute("a://api.gravitee.io/echo")).isFalse();
+        }
 
-    @Test
-    public void test5() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("?k=");
-        Assertions.assertEquals(1, parameters.size());
-        Assertions.assertEquals("", parameters.get("k").get(0));
-    }
-
-    @Test
-    public void test6() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=v&foo=bar");
-        Assertions.assertEquals(2, parameters.size());
-        Assertions.assertEquals("v", parameters.get("k").get(0));
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-    }
-
-    @Test
-    public void test7() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=v&k=bar");
-        Assertions.assertEquals(1, parameters.size());
-        Assertions.assertEquals("v", parameters.get("k").get(0));
-        Assertions.assertEquals("bar", parameters.get("k").get(1));
-    }
-
-    @Test
-    public void test8() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k==v");
-        Assertions.assertEquals(1, parameters.size());
-        Assertions.assertEquals("=v", parameters.get("k").get(0));
-    }
-
-    @Test
-    public void test9() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=%3Dv");
-        Assertions.assertEquals(1, parameters.size());
-        Assertions.assertEquals("%3Dv", parameters.get("k").get(0));
-    }
-
-    @Test
-    public void test10() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=%253Dv");
-        Assertions.assertEquals(1, parameters.size());
-        Assertions.assertEquals("%253Dv", parameters.get("k").get(0));
-    }
-
-    @Test
-    public void test11() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?foo=bar#123");
-        Assertions.assertEquals(1, parameters.size());
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-    }
-
-    @Test
-    public void test12() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=v;foo=bar");
-        Assertions.assertEquals(2, parameters.size());
-        Assertions.assertEquals("v", parameters.get("k").get(0));
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-    }
-
-    @Test
-    public void test13() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=v&foo=bar;a=b");
-        Assertions.assertEquals(3, parameters.size());
-        Assertions.assertEquals("v", parameters.get("k").get(0));
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-        Assertions.assertEquals("b", parameters.get("a").get(0));
-    }
-
-    @Test
-    public void test14() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=v&foo=bar;a=b&");
-        Assertions.assertEquals(3, parameters.size());
-        Assertions.assertEquals("v", parameters.get("k").get(0));
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-        Assertions.assertEquals("b", parameters.get("a").get(0));
-    }
-
-    @Test
-    public void test15() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=v&foo=bar;a=b;");
-        Assertions.assertEquals(3, parameters.size());
-        Assertions.assertEquals("v", parameters.get("k").get(0));
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-        Assertions.assertEquals("b", parameters.get("a").get(0));
-    }
-
-    @Test
-    public void test16() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("/test?k=&foo=bar");
-        Assertions.assertEquals(2, parameters.size());
-        Assertions.assertEquals("", parameters.get("k").get(0));
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-    }
-
-    @Test
-    public void test17() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("?k");
-        Assertions.assertEquals(1, parameters.size());
-        Assertions.assertNull(parameters.get("k").get(0));
-    }
-
-    @Test
-    public void test18() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("?k&j");
-        Assertions.assertEquals(2, parameters.size());
-        Assertions.assertTrue(parameters.containsKey("k"));
-        Assertions.assertNull(parameters.get("k").get(0));
-        Assertions.assertTrue(parameters.containsKey("j"));
-        Assertions.assertNull(parameters.get("j").get(0));
-    }
-
-    @Test
-    public void test19() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("?foo=bar&k");
-        Assertions.assertEquals(2, parameters.size());
-        Assertions.assertTrue(parameters.containsKey("k"));
-        Assertions.assertNull(parameters.get("k").get(0));
-        Assertions.assertTrue(parameters.containsKey("foo"));
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-    }
-
-    @Test
-    public void test20() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("?k&foo=bar");
-        Assertions.assertEquals(2, parameters.size());
-        Assertions.assertTrue(parameters.containsKey("k"));
-        Assertions.assertNull(parameters.get("k").get(0));
-        Assertions.assertTrue(parameters.containsKey("foo"));
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-    }
-
-    @Test
-    public void test21() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("?foo1=bar&k&foo=bar");
-        Assertions.assertEquals(3, parameters.size());
-        Assertions.assertTrue(parameters.containsKey("k"));
-        Assertions.assertNull(parameters.get("k").get(0));
-        Assertions.assertTrue(parameters.containsKey("foo"));
-        Assertions.assertEquals("bar", parameters.get("foo").get(0));
-        Assertions.assertTrue(parameters.containsKey("foo1"));
-        Assertions.assertEquals("bar", parameters.get("foo1").get(0));
-    }
-
-    @Test
-    public void test22() {
-        MultiValueMap<String, String> parameters = URIUtils.parameters("?foo1&k=v&foo");
-        Assertions.assertEquals(3, parameters.size());
-        Assertions.assertTrue(parameters.containsKey("foo1"));
-        Assertions.assertNull(parameters.get("foo1").get(0));
-        Assertions.assertTrue(parameters.containsKey("foo"));
-        Assertions.assertNull(parameters.get("foo").get(0));
-        Assertions.assertTrue(parameters.containsKey("k"));
-        Assertions.assertEquals("v", parameters.get("k").get(0));
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "http://api.gravitee.io/echo", "https://api.gravitee.io/echo", "any://api.gravitee.io/echo" })
-    public void shouldBeAbsolute(String url) {
-        assertThat(URIUtils.isAbsolute(url)).isTrue();
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = { "a://api.gravitee.io/echo", "api.gravitee.io/echo", "/echo" })
-    public void shouldNotBeAbsolute() {
-        assertThat(URIUtils.isAbsolute("a://api.gravitee.io/echo")).isFalse();
-    }
-
-    @Test
-    public void shouldNotBeAbsoluteWithNull() {
-        assertThat(URIUtils.isAbsolute(null)).isFalse();
+        @Test
+        public void shouldNotBeAbsoluteWithNull() {
+            assertThat(URIUtils.isAbsolute(null)).isFalse();
+        }
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2218
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.3.0-apim-2218-semicolon-query-params-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/2.3.0-apim-2218-semicolon-query-params-SNAPSHOT/gravitee-common-2.3.0-apim-2218-semicolon-query-params-SNAPSHOT.zip)
  <!-- Version placeholder end -->
