### PR TITLE
fix: return false when given matching tags is null or empty

### DIFF
--- a/src/main/java/io/gravitee/common/util/EnvironmentUtils.java
+++ b/src/main/java/io/gravitee/common/util/EnvironmentUtils.java
@@ -91,19 +91,15 @@ public final class EnvironmentUtils {
     public static boolean hasMatchingTags(Optional<List<String>> configuredTags, Set<String> tags) {
         if (configuredTags.isPresent()) {
             List<String> tagList = configuredTags.get();
-            if (tags != null) {
-                final List<String> inclusionTags = tagList
-                    .stream()
-                    .map(String::trim)
-                    .filter(tag -> !tag.startsWith("!"))
-                    .collect(Collectors.toList());
+            if (tags != null && !tags.isEmpty()) {
+                final List<String> inclusionTags = tagList.stream().map(String::trim).filter(tag -> !tag.startsWith("!")).toList();
 
                 final List<String> exclusionTags = tagList
                     .stream()
                     .map(String::trim)
                     .filter(tag -> tag.startsWith("!"))
                     .map(tag -> tag.substring(1))
-                    .collect(Collectors.toList());
+                    .toList();
 
                 if (inclusionTags.stream().anyMatch(exclusionTags::contains)) {
                     throw new IllegalArgumentException("You must not configure a tag to be included and excluded");
@@ -113,6 +109,8 @@ public final class EnvironmentUtils {
                     (inclusionTags.isEmpty() || tagsContains(inclusionTags, tags)) &&
                     (exclusionTags.isEmpty() || !tagsContains(exclusionTags, tags))
                 );
+            } else {
+                return false;
             }
         }
 

--- a/src/test/java/io/gravitee/common/util/EnvironmentUtilsTest.java
+++ b/src/test/java/io/gravitee/common/util/EnvironmentUtilsTest.java
@@ -19,6 +19,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.*;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -88,7 +91,7 @@ public class EnvironmentUtilsTest {
     public void should_fail_if_tag_is_included_and_excluded() {
         assertThrows(
             IllegalArgumentException.class,
-            () -> EnvironmentUtils.hasMatchingTags(Optional.of(Arrays.asList("env", "!env")), new HashSet<>())
+            () -> EnvironmentUtils.hasMatchingTags(Optional.of(Arrays.asList("env", "!env")), new HashSet<>(Arrays.asList("env")))
         );
     }
 
@@ -120,5 +123,12 @@ public class EnvironmentUtilsTest {
     @Test
     public void should_return_false_if_no_matching_tag() {
         assertFalse(EnvironmentUtils.hasMatchingTags(Optional.of(Arrays.asList("env1", "!env2")), new HashSet<>(Arrays.asList("env3"))));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EmptySource
+    public void should_return_false_if_empty_tags(final Set<String> tags) {
+        assertFalse(EnvironmentUtils.hasMatchingTags(Optional.of(Arrays.asList("env1", "!env2")), tags));
     }
 }


### PR DESCRIPTION
**Description**

When creating a api v4, tags param could be null otherwise we didn't check this and return true even if the gateway has been setup with tags.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.1-fix-has-matching-tags-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/3.2.1-fix-has-matching-tags-SNAPSHOT/gravitee-common-3.2.1-fix-has-matching-tags-SNAPSHOT.zip)
  <!-- Version placeholder end -->
