### PR TITLE
feat: add reusable freemarker templating component

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.2</version>
+        <version>22.0.4</version>
     </parent>
 
     <groupId>io.gravitee.common</groupId>
@@ -34,12 +34,11 @@
     <name>Gravitee.io APIM - Common</name>
 
     <properties>
-        <gravitee-bom.version>4.0.0</gravitee-bom.version>
+        <gravitee-bom.version>6.0.4</gravitee-bom.version>
         <gravitee-node.version>2.0.0</gravitee-node.version>
         <java-uuid-generator.version>3.1.4</java-uuid-generator.version>
         <bouncycastle.version>1.69</bouncycastle.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
-        <lombok.version>1.18.24</lombok.version>
         <freemarker.version>2.3.31</freemarker.version>
     </properties>
 
@@ -96,6 +95,7 @@
             <version>${bouncycastle.version}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
@@ -114,7 +114,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
         </dependency>
 
         <!-- Templating -->
@@ -130,11 +129,13 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
@@ -153,26 +154,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.hubspot.maven.plugins</groupId>
-                <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.17</version>
-                <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>validate</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <bouncycastle.version>1.69</bouncycastle.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <lombok.version>1.18.24</lombok.version>
+        <freemarker.version>2.3.31</freemarker.version>
     </properties>
 
     <dependencyManagement>
@@ -114,6 +115,13 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+        </dependency>
+
+        <!-- Templating -->
+        <dependency>
+            <groupId>org.freemarker</groupId>
+            <artifactId>freemarker</artifactId>
+            <version>${freemarker.version}</version>
         </dependency>
 
         <!-- Unit Tests -->

--- a/src/main/java/io/gravitee/common/templating/FreeMarkerComponent.java
+++ b/src/main/java/io/gravitee/common/templating/FreeMarkerComponent.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.templating;
+
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.cache.FileTemplateLoader;
+import freemarker.cache.MultiTemplateLoader;
+import freemarker.cache.TemplateLoader;
+import freemarker.core.TemplateClassResolver;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Antoine CORDIER (antoine.cordier at graviteesource.com)
+ * @author GraviteeSource Team
+ *
+ * Utility component that compiles freemarker templates from various source to various outputs.
+ *
+ * This can be used in plugins as it handles template loading from the parent classloader.
+ *
+ * To be resolved from the class path, templates *must* reside in the `freemarker` resources package.
+ */
+public class FreeMarkerComponent {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FreeMarkerComponent.class);
+
+    private static final String TEMPLATES_BASE = "/freemarker";
+
+    private final Configuration freeMarkerConfiguration;
+
+    /**
+     * Create a FreeMarker component with default configuration, meaning that templates are loaded from
+     * a freemarker resources package located in the classpath, using the current classloader and its parent.
+     * The parent classloader takes precedence over the current classloader.
+     * {@see #freemarker.cache.ClassTemplateLoader(Class, String)}
+     */
+    public FreeMarkerComponent() {
+        this("");
+    }
+
+    /**
+     * Convenience constructor to create a FreeMarker component which will load templates from a subpackage
+     * inside the freemarker resources package.
+     * {@link FreeMarkerComponent#FreeMarkerComponent()}
+     */
+    public FreeMarkerComponent(String subPackagePath) {
+        var basePackagePath = sanitizeBasePackage(subPackagePath);
+        this.freeMarkerConfiguration = freemarkerConfiguration(basePackagePath);
+    }
+
+    /**
+     * Creates a FreeMarker component which will look for templates from a given path on the file system first,
+     * and fallback to the classpath loader.
+     */
+    public FreeMarkerComponent(Path path) {
+        this(path, "");
+    }
+
+    /**
+     * Creates a FreeMarker component which will look for templates from a given path on the file system first,
+     * and fallback to the freemarker resources subpackage.
+     * {@link FreeMarkerComponent#FreeMarkerComponent(String)}
+     * {@link FreeMarkerComponent#FreeMarkerComponent(Path)}
+     */
+    public FreeMarkerComponent(Path path, String subPackagePath) {
+        var basePackagePath = sanitizeBasePackage(subPackagePath);
+        this.freeMarkerConfiguration = freemarkerConfiguration(path, basePackagePath);
+    }
+
+    /**
+     * Compiles the free marker template and writes the result to the writer.
+     * @param templateName name of the FreeMarker template
+     * @param data data of the template
+     * @param writer writer to write the result to
+     */
+    public void generateFromTemplate(final String templateName, final Map<String, Object> data, Writer writer) {
+        try {
+            final Template template = freeMarkerConfiguration.getTemplate(templateName);
+            template.process(data, writer);
+        } catch (final IOException | TemplateException exception) {
+            LOG.error("Impossible to generate from template " + templateName, exception);
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /**
+     * Compiles the free marker template and returns the result as a string.
+     * @param templateName name of the FreeMarker template
+     * @param data data of the template
+     * @return compiled template as a string
+     */
+    public String generateFromTemplate(final String templateName, final Map<String, Object> data) {
+        try (final StringWriter output = new StringWriter()) {
+            generateFromTemplate(templateName, data, output);
+            return output.getBuffer().toString();
+        } catch (final IOException exception) {
+            LOG.error("Impossible to generate from template {}", templateName, exception);
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private static String sanitizeBasePackage(String subPackagePath) {
+        return subPackagePath.startsWith("/") ? TEMPLATES_BASE + subPackagePath : TEMPLATES_BASE + "/" + subPackagePath;
+    }
+
+    private static Configuration freemarkerConfiguration(String templatesLocation) {
+        var configuration = commonFreemarkerConfiguration();
+        configuration.setTemplateLoader(classTemplateLoader(templatesLocation));
+        return configuration;
+    }
+
+    private static Configuration freemarkerConfiguration(Path path, String basePackagePath) {
+        var configuration = commonFreemarkerConfiguration();
+        configuration.setTemplateLoader(fileTemplateLoader(path, basePackagePath));
+        return configuration;
+    }
+
+    private static Configuration commonFreemarkerConfiguration() {
+        var configuration = new Configuration(Configuration.VERSION_2_3_23);
+        configuration.setDefaultEncoding(StandardCharsets.UTF_8.name());
+        configuration.setDateFormat("iso_utc");
+        configuration.setLocale(Locale.ENGLISH);
+        configuration.setNumberFormat("computer");
+        configuration.setNewBuiltinClassResolver(TemplateClassResolver.SAFER_RESOLVER);
+        return configuration;
+    }
+
+    private static TemplateLoader fileTemplateLoader(Path path, String templateLocation) {
+        try {
+            var fileTemplateLoader = new FileTemplateLoader(path.toFile());
+            var classTemplateLoader = classTemplateLoader(templateLocation);
+            return new MultiTemplateLoader(new TemplateLoader[] { fileTemplateLoader, classTemplateLoader });
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Unable to initialize template loader", e);
+        }
+    }
+
+    private static TemplateLoader classTemplateLoader(String templatesLocation) {
+        var classLoader = FreeMarkerComponent.class.getClassLoader();
+        var templateLoader = new ClassTemplateLoader(classLoader, templatesLocation);
+        if (classLoader.getParent() != null) {
+            var parentTemplateLoader = new ClassTemplateLoader(classLoader.getParent(), templatesLocation);
+            return new MultiTemplateLoader(new TemplateLoader[] { parentTemplateLoader, templateLoader });
+        }
+        return templateLoader;
+    }
+}

--- a/src/test/java/io/gravitee/common/templating/FreeMarkerComponentTest.java
+++ b/src/test/java/io/gravitee/common/templating/FreeMarkerComponentTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.templating;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class FreeMarkerComponentTest {
+
+    private static final Map<String, Object> DATA = Map.of("message", "It works!");
+
+    private static final String TEMPLATE = "template.ftl";
+
+    @Test
+    void should_read_template_from_base_package() {
+        var freeMarkerComponent = new FreeMarkerComponent();
+        var result = freeMarkerComponent.generateFromTemplate(TEMPLATE, DATA);
+        assertThat(result)
+            .isEqualToIgnoringNewLines("""
+      { "description" : "from freemarker package", "message" : "It works!" }
+      """);
+    }
+
+    @Test
+    void should_read_template_from_sub_package() {
+        var freeMarkerComponent = new FreeMarkerComponent("subpackage");
+        var result = freeMarkerComponent.generateFromTemplate(TEMPLATE, DATA);
+        assertThat(result)
+            .isEqualToIgnoringNewLines("""
+      { "description" : "from freemarker sub package", "message" : "It works!" }
+      """);
+    }
+
+    @Test
+    void should_read_templates_from_file_system(@TempDir Path tempDir) throws IOException {
+        var freeMarkerComponent = new FreeMarkerComponent(tempDir);
+        var fsTemplate = tempDir.resolve(TEMPLATE);
+
+        Files.write(fsTemplate, """
+    { "description" : "from file system", "message" : "${message}" }
+    """.getBytes());
+
+        var result = freeMarkerComponent.generateFromTemplate(TEMPLATE, DATA);
+        assertThat(result).isEqualToIgnoringNewLines("""
+      { "description" : "from file system", "message" : "It works!" }
+      """);
+    }
+}

--- a/src/test/resources/freemarker/subpackage/template.ftl
+++ b/src/test/resources/freemarker/subpackage/template.ftl
@@ -1,0 +1,6 @@
+<@compress single_line=true>
+  {
+  "description" : "from freemarker sub package",
+  "message" : "${message}"
+  }
+</@compress>

--- a/src/test/resources/freemarker/template.ftl
+++ b/src/test/resources/freemarker/template.ftl
@@ -1,0 +1,6 @@
+<@compress single_line=true>
+  {
+  "description" : "from freemarker package",
+  "message" : "${message}"
+  }
+</@compress>


### PR DESCRIPTION
Both gravitee-reporter-common and gravitee-common-elasticsearch define their own FreemarkerComponent. 

The only diff between those two implementations is that one of them injects a Spring value to read templates from the FS.

One or the other of those implementation are used in:
  - gravitee-reporter-common (its own implem)
  - gravitee-reporter-elasticsearch (which uses the one from common-elasticsearch, but indirectly  also the one from reporter-common as it depends on it for formatting)
  - gravitee-api-management (for seeding data in our elasticsearch-repository tests)
  
As templating capability does not really have to do with reporting or with elasticsearch, the idea of this PR is to make this utility class re-usable whatever the context is and to put it in a common place to be reused by other components.

If we do so, the reporter-common will depend on this implementation and the common-elasticsearch implementation will be marked as deprecated and for removal (to leave us the time to update APIM accordingly)

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.3.0-feat-add-freemarker-component-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/3.3.0-feat-add-freemarker-component-SNAPSHOT/gravitee-common-3.3.0-feat-add-freemarker-component-SNAPSHOT.zip)
  <!-- Version placeholder end -->
