### PR TITLE
fix: improving environment hasMatching feature

### DIFF
--- a/src/main/java/io/gravitee/common/util/EnvironmentUtils.java
+++ b/src/main/java/io/gravitee/common/util/EnvironmentUtils.java
@@ -16,8 +16,13 @@
 package io.gravitee.common.util;
 
 import java.text.Collator;
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.CompositePropertySource;
@@ -91,27 +96,20 @@ public final class EnvironmentUtils {
     public static boolean hasMatchingTags(Optional<List<String>> configuredTags, Set<String> tags) {
         if (configuredTags.isPresent()) {
             List<String> tagList = configuredTags.get();
-            if (tags != null && !tags.isEmpty()) {
-                final List<String> inclusionTags = tagList.stream().map(String::trim).filter(tag -> !tag.startsWith("!")).toList();
 
-                final List<String> exclusionTags = tagList
-                    .stream()
-                    .map(String::trim)
-                    .filter(tag -> tag.startsWith("!"))
-                    .map(tag -> tag.substring(1))
-                    .toList();
+            final List<String> inclusionTags = tagList.stream().map(String::trim).filter(tag -> !tag.startsWith("!")).toList();
 
-                if (inclusionTags.stream().anyMatch(exclusionTags::contains)) {
-                    throw new IllegalArgumentException("You must not configure a tag to be included and excluded");
-                }
+            final List<String> exclusionTags = tagList
+                .stream()
+                .map(String::trim)
+                .filter(tag -> tag.startsWith("!"))
+                .map(tag -> tag.substring(1))
+                .toList();
 
-                return (
-                    (inclusionTags.isEmpty() || tagsContains(inclusionTags, tags)) &&
-                    (exclusionTags.isEmpty() || !tagsContains(exclusionTags, tags))
-                );
-            } else {
-                return false;
-            }
+            return (
+                (inclusionTags.isEmpty() || tagsContains(inclusionTags, tags)) &&
+                (exclusionTags.isEmpty() || !tagsContains(exclusionTags, tags))
+            );
         }
 
         // no tags configured on this gateway instance
@@ -139,6 +137,9 @@ public final class EnvironmentUtils {
     }
 
     private static boolean tagsContains(Collection<String> tags, Collection<String> searchedTags) {
+        if (searchedTags == null || searchedTags.isEmpty()) {
+            return false;
+        }
         return tags
             .stream()
             .anyMatch(tag ->

--- a/src/test/java/io/gravitee/common/util/EnvironmentUtilsTest.java
+++ b/src/test/java/io/gravitee/common/util/EnvironmentUtilsTest.java
@@ -15,13 +15,21 @@
  */
 package io.gravitee.common.util;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -88,16 +96,20 @@ public class EnvironmentUtilsTest {
     }
 
     @Test
-    public void should_fail_if_tag_is_included_and_excluded() {
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> EnvironmentUtils.hasMatchingTags(Optional.of(Arrays.asList("env", "!env")), new HashSet<>(Arrays.asList("env")))
-        );
+    public void should_return_false_if_tag_is_included_and_excluded() {
+        assertFalse(EnvironmentUtils.hasMatchingTags(Optional.of(Arrays.asList("env", "!env")), new HashSet<>(Arrays.asList("env"))));
     }
 
     @Test
     public void should_return_true_if_one_matching_tag_in_included_list() {
         assertTrue(EnvironmentUtils.hasMatchingTags(Optional.of(Arrays.asList("env")), new HashSet<>(Arrays.asList("env"))));
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @EmptySource
+    public void should_return_true_if_empty_matching_tag_in_excluded_list(final Set<String> tags) {
+        assertTrue(EnvironmentUtils.hasMatchingTags(Optional.of(Arrays.asList("!env")), tags));
     }
 
     @Test


### PR DESCRIPTION
**Description**

  - if the provided tags are null or empty, and the gateway has exclusion tags, it will now return true
  - if a tag is in the inclusion and exclusion lists, the method returns false.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.3.1-improve-matching-tags-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/3.3.1-improve-matching-tags-SNAPSHOT/gravitee-common-3.3.1-improve-matching-tags-SNAPSHOT.zip)
  <!-- Version placeholder end -->
