### PR TITLE
fix: allow to extract non-encoded certificate

### DIFF
--- a/src/main/java/io/gravitee/common/security/CertificateUtils.java
+++ b/src/main/java/io/gravitee/common/security/CertificateUtils.java
@@ -49,7 +49,10 @@ public class CertificateUtils {
 
         if (certHeaderValue != null) {
             try {
-                certHeaderValue = URLDecoder.decode(certHeaderValue.replaceAll("\t", "\n"), Charset.defaultCharset());
+                if (!certHeaderValue.contains("\n")) {
+                    certHeaderValue = URLDecoder.decode(certHeaderValue, Charset.defaultCharset());
+                }
+                certHeaderValue = certHeaderValue.replaceAll("\t", "\n");
                 CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
                 certificate =
                     Optional.ofNullable(

--- a/src/test/java/io/gravitee/common/security/CertificateUtilsTest.java
+++ b/src/test/java/io/gravitee/common/security/CertificateUtilsTest.java
@@ -66,9 +66,20 @@ class CertificateUtilsTest {
     }
 
     @Test
-    void should_extract_certificate_from_header() {
+    void should_extract_encoded_certificate_from_header() {
         HttpHeaders httpHeaders = HttpHeaders.create();
         httpHeaders.set(CLIENT_CERT_HEADER, URLEncoder.encode(clientCertificate, StandardCharsets.UTF_8));
+        Optional<X509Certificate> certificateOptional = CertificateUtils.extractCertificate(httpHeaders, CLIENT_CERT_HEADER);
+
+        assertThat(certificateOptional).isNotEmpty();
+        X509Certificate certificate = certificateOptional.get();
+        assertThat(certificate).isEqualTo(clientX509Certificate);
+    }
+
+    @Test
+    void should_extract_non_encoded_certificate_from_header() {
+        HttpHeaders httpHeaders = HttpHeaders.create();
+        httpHeaders.set(CLIENT_CERT_HEADER, clientCertificate);
         Optional<X509Certificate> certificateOptional = CertificateUtils.extractCertificate(httpHeaders, CLIENT_CERT_HEADER);
 
         assertThat(certificateOptional).isNotEmpty();


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-2555

**Description**

Not exactly related to the issue but allow to use encoded or non encoded certificate

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.3.1-apim-2555-allow-non-encoded-certificate-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/3.3.1-apim-2555-allow-non-encoded-certificate-SNAPSHOT/gravitee-common-3.3.1-apim-2555-allow-non-encoded-certificate-SNAPSHOT.zip)
  <!-- Version placeholder end -->
