### PR TITLE
feat: introduce CronTrigger class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
             <artifactId>vertx-core</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-rx-java3</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <!-- UUID generator -->
         <dependency>

--- a/src/main/java/io/gravitee/common/cron/CronTrigger.java
+++ b/src/main/java/io/gravitee/common/cron/CronTrigger.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.cron;
+
+import io.gravitee.common.utils.TimeProvider;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.support.SimpleTriggerContext;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@Slf4j
+public class CronTrigger {
+
+    private final SimpleTriggerContext triggerContext;
+    private final org.springframework.scheduling.support.CronTrigger delegate;
+
+    public CronTrigger(String schedule) {
+        delegate = new org.springframework.scheduling.support.CronTrigger(schedule);
+        triggerContext = new SimpleTriggerContext(TimeProvider.clock());
+    }
+
+    /**
+     * Compute the delay to next execution
+     * @return the delay in milliseconds to the next execution time
+     */
+    public long nextExecutionIn() {
+        final Instant nextExecutionDate = delegate.nextExecution(triggerContext);
+
+        if (nextExecutionDate == null) {
+            return Long.MAX_VALUE;
+        }
+
+        return ChronoUnit.MILLIS.between(TimeProvider.instantNow(), nextExecutionDate);
+    }
+}

--- a/src/main/java/io/gravitee/common/utils/TimeProvider.java
+++ b/src/main/java/io/gravitee/common/utils/TimeProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.utils;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+
+/**
+ * TimeProvider to use instead of Instant class.
+ * It facilitates the testing around Time.
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class TimeProvider {
+
+    private TimeProvider() {}
+
+    private static Clock clock = Clock.systemDefaultZone();
+
+    public static ZonedDateTime now() {
+        return ZonedDateTime.now(clock);
+    }
+
+    public static Instant instantNow() {
+        return Instant.now(clock);
+    }
+
+    public static void overrideClock(Clock clock) {
+        TimeProvider.clock = clock;
+    }
+
+    public static Clock clock() {
+        return clock;
+    }
+
+    public static void reset() {
+        TimeProvider.clock = Clock.systemDefaultZone();
+    }
+}

--- a/src/test/java/io/gravitee/common/cron/CronTriggerTest.java
+++ b/src/test/java/io/gravitee/common/cron/CronTriggerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.cron;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.gravitee.common.utils.TimeProvider;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class CronTriggerTest {
+
+    private static final Instant INSTANT_NOW = Instant.parse("2024-02-01T10:15:12Z");
+
+    @BeforeAll
+    static void beforeAll() {
+        TimeProvider.overrideClock(Clock.fixed(INSTANT_NOW, ZoneId.systemDefault()));
+    }
+
+    @AfterAll
+    static void afterAll() {
+        TimeProvider.reset();
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        {
+            // Every 30 seconds
+            "*/30 * * * * *, 2024-02-01T10:15:12Z, 2024-02-01T10:15:30Z",
+            // Every 30 seconds
+            "*/30 * * * * *, 2024-02-01T10:15:29Z, 2024-02-01T10:15:30Z",
+            // Every 60 seconds
+            "*/60 * * * * *, 2024-02-01T10:15:29Z, 2024-02-01T10:16:00Z",
+            // Every even minute
+            "0 */2 * ? * *, 2024-02-01T10:15:29Z, 2024-02-01T10:16:00Z",
+            // Every even minute
+            "0 */2 * ? * *, 2024-02-01T10:14:29Z, 2024-02-01T10:16:00Z",
+        }
+    )
+    void should_get_next_execution_time(String cronExpression, String fakeNow, String expectedNextExecutionTime) {
+        final Instant instantNow = Instant.parse(fakeNow);
+        TimeProvider.overrideClock(Clock.fixed(instantNow, ZoneId.systemDefault()));
+        final long result = new CronTrigger(cronExpression).nextExecutionIn();
+
+        assertThat(instantNow.plus(result, ChronoUnit.MILLIS)).isEqualTo(Instant.parse(expectedNextExecutionTime));
+    }
+
+    @Test
+    void should_throw_on_invalid_cron() {
+        assertThatThrownBy(() -> new CronTrigger("invalid")).isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-3368

**Description**
Introduce CronTrigger to share computation of Cron expression for nextExecutionTime across all products.

For testing facilities, We also introduce TimeProvider to be able to control the Clock from tests.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.4.0-apim-3368-v4-dynamic-properties-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/3.4.0-apim-3368-v4-dynamic-properties-SNAPSHOT/gravitee-common-3.4.0-apim-3368-v4-dynamic-properties-SNAPSHOT.zip)
  <!-- Version placeholder end -->
