### PR TITLE
chore: update gravitee dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.1.0
+    gravitee: gravitee-io/gravitee@4.1.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,25 @@
 {
-    "extends": ["config:base", "schedule:earlyMondays"],
-    "prConcurrentLimit": 3,
+    "extends": ["config:base", ":label(dependencies)"],
     "rebaseWhen": "conflicted",
     "packageRules": [
         {
             "matchDatasources": ["orb"],
-            "rangeStrategy": "replace"
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "ci"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["patch", "minor"],
+            "automerge": true,
+            "automergeType": "branch",
+            "semanticCommitType": "chore"
+        },
+        {
+            "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+            "matchUpdateTypes": ["major"],
+            "semanticCommitType": "chore"
         }
     ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.0.4</version>
+        <version>22.0.19</version>
     </parent>
 
     <groupId>io.gravitee.common</groupId>
@@ -34,8 +34,8 @@
     <name>Gravitee.io APIM - Common</name>
 
     <properties>
-        <gravitee-bom.version>6.0.4</gravitee-bom.version>
-        <gravitee-node.version>2.0.0</gravitee-node.version>
+        <gravitee-bom.version>6.0.24</gravitee-bom.version>
+        <gravitee-node.version>4.8.2</gravitee-node.version>
         <java-uuid-generator.version>3.1.4</java-uuid-generator.version>
         <bouncycastle.version>1.69</bouncycastle.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>


### PR DESCRIPTION
**Description**

Keep gravitee-bom 6.x to be compatible with the majority of APIM version.


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->