### PR TITLE
fix(deps): update bcprov-jdk15on to bcprov-jdk18on

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>6.0.4</gravitee-bom.version>
         <gravitee-node.version>2.0.0</gravitee-node.version>
         <java-uuid-generator.version>3.1.4</java-uuid-generator.version>
-        <bouncycastle.version>1.69</bouncycastle.version>
+        <bouncycastle.version>1.77</bouncycastle.version>
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <freemarker.version>2.3.31</freemarker.version>
     </properties>
@@ -96,14 +96,14 @@
         <!-- Bouncy Castle -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4028

**Description**

The library https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on has been moved to https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on

**Additional context**

The main goal of this task is to update the library and resolve vulnerability issues:
https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6084022