### PR TITLE
feat: allow to filter retryable exception

### DIFF
--- a/src/main/java/io/gravitee/common/utils/RxHelper.java
+++ b/src/main/java/io/gravitee/common/utils/RxHelper.java
@@ -124,57 +124,6 @@ public class RxHelper {
     }
 
     /**
-     * Returns a {@link FlowableTransformer} that can be used in a composition.
-     * It will progressively wait longer intervals between consecutive retries of the {@link Flowable}.
-     * The initial delay is used as the beginning, then the factor of 2 is used to build the second delay without max limitation.
-     *
-     * @param initialDelay  the initial delay to wait
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay
-     * @return a {@link FlowableTransformer} that will be applied.
-     */
-    public static <R> FlowableTransformer<R, R> retryExponentialBackoffFlowable(final long initialDelay, final TimeUnit timeUnit) {
-        return upstream -> upstream.retryWhen(retryExponentialBackoff(initialDelay, timeUnit));
-    }
-
-    /**
-     * Returns a {@link FlowableTransformer} that can be used in a composition.
-     * It will progressively wait longer intervals between consecutive retries of the {@link Flowable}.
-     * The initial delay is used as the beginning, then the factor of 2 is used to build the second delay until it reaches the maxDelay.
-     *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
-     * @return a {@link FlowableTransformer} that will be applied.
-     */
-    public static <R> FlowableTransformer<R, R> retryExponentialBackoffFlowable(
-        final long initialDelay,
-        final long maxDelay,
-        final TimeUnit timeUnit
-    ) {
-        return upstream -> upstream.retryWhen(retryExponentialBackoff(initialDelay, maxDelay, timeUnit));
-    }
-
-    /**
-     * Returns a {@link FlowableTransformer} that can be used in a composition.
-     * It will progressively wait longer intervals between consecutive retries of the {@link Flowable}.
-     * The initial delay is used as the beginning, then the factor is used to build the second delay until it reaches the maxDelay.
-     *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
-     * @param factor        factor used to compute next delay
-     * @return a {@link FlowableTransformer} that will be applied.
-     */
-    public static <R> FlowableTransformer<R, R> retryExponentialBackoffFlowable(
-        final long initialDelay,
-        final long maxDelay,
-        final TimeUnit timeUnit,
-        final double factor
-    ) {
-        return upstream -> upstream.retryWhen(retryExponentialBackoff(initialDelay, maxDelay, timeUnit, factor));
-    }
-
-    /**
      * Same as {@link #retryFlowable(int, int, TimeUnit)} but with a {@link Maybe} instead.
      *
      * @param times         the attempts number
@@ -209,57 +158,6 @@ public class RxHelper {
             upstream.retryWhen(throwables ->
                 throwables.compose(delayElement(retryInterval, timeUnit, skipThrowable)).compose(takeThenThrow(times, skipThrowable))
             );
-    }
-
-    /**
-     * Returns a {@link MaybeTransformer} that can be used in a composition.
-     * It will progressively wait longer intervals between consecutive retries of the {@link Maybe}.
-     * The initial delay is used as the beginning, then the factor of 2 is used to build the second delay without max limitation.
-     *
-     * @param initialDelay  the initial delay to wait
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay
-     * @return a {@link MaybeTransformer} that will be applied.
-     */
-    public static <R> MaybeTransformer<R, R> retryExponentialBackoffMaybe(final long initialDelay, final TimeUnit timeUnit) {
-        return upstream -> upstream.retryWhen(retryExponentialBackoff(initialDelay, timeUnit));
-    }
-
-    /**
-     * Returns a {@link MaybeTransformer} that can be used in a composition.
-     * It will progressively wait longer intervals between consecutive retries of the {@link Maybe}.
-     * The initial delay is used as the beginning, then the factor of 2 is used to build the second delay until it reaches the maxDelay.
-     *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
-     * @return a {@link MaybeTransformer} that will be applied.
-     */
-    public static <R> MaybeTransformer<R, R> retryExponentialBackoffMaybe(
-        final long initialDelay,
-        final long maxDelay,
-        final TimeUnit timeUnit
-    ) {
-        return upstream -> upstream.retryWhen(retryExponentialBackoff(initialDelay, maxDelay, timeUnit));
-    }
-
-    /**
-     * Returns a {@link MaybeTransformer} that can be used in a composition.
-     * It will progressively wait longer intervals between consecutive retries of the {@link Maybe}.
-     * The initial delay is used as the beginning, then the factor is used to build the second delay until it reaches the maxDelay.
-     *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
-     * @param factor        factor used to compute next delay
-     * @return a {@link MaybeTransformer} that will be applied.
-     */
-    public static <R> MaybeTransformer<R, R> retryExponentialBackoffMaybe(
-        final long initialDelay,
-        final long maxDelay,
-        final TimeUnit timeUnit,
-        final double factor
-    ) {
-        return upstream -> upstream.retryWhen(retryExponentialBackoff(initialDelay, maxDelay, timeUnit, factor));
     }
 
     /**
@@ -298,57 +196,6 @@ public class RxHelper {
             upstream.retryWhen(throwables ->
                 throwables.compose(delayElement(retryInterval, timeUnit, skipThrowable)).compose(takeThenThrow(times, skipThrowable))
             );
-    }
-
-    /**
-     * Returns a {@link SingleTransformer} that can be used in a composition.
-     * It will progressively wait longer intervals between consecutive retries of the {@link Single}.
-     * The initial delay is used as the beginning, then the factor of 2 is used to build the second delay without max limitation.
-     *
-     * @param initialDelay  the initial delay to wait
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay
-     * @return a {@link SingleTransformer} that will be applied.
-     */
-    public static <R> SingleTransformer<R, R> retryExponentialBackoffSingle(final long initialDelay, final TimeUnit timeUnit) {
-        return upstream -> upstream.retryWhen(retryExponentialBackoff(initialDelay, timeUnit));
-    }
-
-    /**
-     * Returns a {@link SingleTransformer} that can be used in a composition.
-     * It will progressively wait longer intervals between consecutive retries of the {@link Single}.
-     * The initial delay is used as the beginning, then the factor of 2 is used to build the second delay until it reaches the maxDelay.
-     *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
-     * @return a {@link SingleTransformer} that will be applied.
-     */
-    public static <R> SingleTransformer<R, R> retryExponentialBackoffSingle(
-        final long initialDelay,
-        final long maxDelay,
-        final TimeUnit timeUnit
-    ) {
-        return upstream -> upstream.retryWhen(retryExponentialBackoff(initialDelay, maxDelay, timeUnit));
-    }
-
-    /**
-     * Returns a {@link SingleTransformer} that can be used in a composition.
-     * It will progressively wait longer intervals between consecutive retries of the {@link Single}.
-     * The initial delay is used as the beginning, then the factor is used to build the second delay until it reaches the maxDelay.
-     *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
-     * @param factor        factor used to compute next delay
-     * @return a {@link SingleTransformer} that will be applied.
-     */
-    public static <R> SingleTransformer<R, R> retryExponentialBackoffSingle(
-        final long initialDelay,
-        final long maxDelay,
-        final TimeUnit timeUnit,
-        final double factor
-    ) {
-        return upstream -> upstream.retryWhen(retryExponentialBackoff(initialDelay, maxDelay, timeUnit, factor));
     }
 
     /**
@@ -418,7 +265,7 @@ public class RxHelper {
      * @param timeUnit      the {@link TimeUnit} of the initialDelay
      * @return a {@link Function} that will be applied.
      */
-    private static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
+    public static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
         final long initialDelay,
         final TimeUnit timeUnit
     ) {
@@ -434,7 +281,7 @@ public class RxHelper {
      * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
      * @return a {@link Function} that will be applied.
      */
-    private static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
+    public static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
         final long initialDelay,
         final long maxDelay,
         final TimeUnit timeUnit
@@ -452,14 +299,43 @@ public class RxHelper {
      * @param factor        factor used to compute next delay
      * @return a {@link Function} that will be applied.
      */
-    private static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
+    public static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
         final long initialDelay,
         final long maxDelay,
         final TimeUnit timeUnit,
         final double factor
     ) {
+        return retryExponentialBackoff(initialDelay, maxDelay, timeUnit, factor, TRUE_PREDICATE);
+    }
+
+    /**
+     * It will progressively wait longer intervals between consecutive retries.
+     * The initial delay is used as the beginning, then the factor is used to build the second delay until it reaches the maxDelay.
+     *
+     * @param initialDelay  the initial delay to wait
+     * @param maxDelay      the max delay
+     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
+     * @param factor        factor used to compute next delay
+     * @param retryPredicate the predicate to test if instance of {@link Throwable} has to be retried, else, emits directly the error
+     * @return a {@link Function} that will be applied.
+     */
+    public static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
+        final long initialDelay,
+        final long maxDelay,
+        final TimeUnit timeUnit,
+        final double factor,
+        Predicate<Throwable> retryPredicate
+    ) {
+        Objects.requireNonNull(retryPredicate, "retryPredicate is null");
         return attempts ->
             attempts
+                .flatMapSingle(throwable -> {
+                    if (retryPredicate.test(throwable)) {
+                        return Single.just(throwable);
+                    } else {
+                        return Single.error(throwable);
+                    }
+                })
                 .zipWith(Flowable.range(1, Integer.MAX_VALUE), (throwable, attemptNumber) -> attemptNumber)
                 .map(attemptNumber -> {
                     long delayMs = Math.round(Math.pow(factor, attemptNumber.doubleValue() - 1) * timeUnit.toMillis(initialDelay));

--- a/src/test/java/io/gravitee/common/utils/RxHelperTest.java
+++ b/src/test/java/io/gravitee/common/utils/RxHelperTest.java
@@ -148,46 +148,6 @@ class RxHelperTest {
     }
 
     @Test
-    @DisplayName("Should retry exponentially Flowable and finally success after 2 retries")
-    void shouldExponentiallyRetryFlowable() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestSubscriber<Object> obs = Flowable
-                .generate(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 2) {
-                        emitter.onError(new RuntimeException());
-                    } else if (cpt <= 4) {
-                        emitter.onNext(cpt);
-                    } else {
-                        emitter.onComplete();
-                    }
-                })
-                .compose(RxHelper.retryExponentialBackoffFlowable(10, TimeUnit.SECONDS))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
-
-            // an exception has been thrown, so try to retry after ten seconds
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoValues();
-
-            // Second retry should take longer than first one as factor equals 2
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoValues();
-
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertComplete().assertValueAt(0, value -> value.equals(3)).assertValueAt(1, value -> value.equals(4));
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
     @DisplayName("Should not retry Flowable according to filter predicate")
     void shouldNotRetryFlowableAccordingToPredicate() {
         try {
@@ -253,40 +213,6 @@ class RxHelperTest {
     }
 
     @Test
-    @DisplayName("Should retry exponentially Maybe and finally success after 2 retries")
-    void shouldExponentiallyRetryMaybe() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Integer> obs = Maybe
-                .<Integer>create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt < 3) {
-                        emitter.onError(new RuntimeException());
-                    } else {
-                        emitter.onSuccess(cpt);
-                    }
-                })
-                .compose(RxHelper.retryExponentialBackoffMaybe(10, TimeUnit.SECONDS))
-                .test();
-
-            // First retry should wait 10sec
-            obs.assertNotComplete().assertNoValues();
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            // Second retry should wait 20sec
-            obs.assertNotComplete().assertNoValues();
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertComplete().assertValueAt(0, value -> value.equals(3));
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
     @DisplayName("Should not retry Maybe according to retry predicate")
     void shouldNotRetryMaybeAccordingToPredicate() {
         try {
@@ -344,40 +270,6 @@ class RxHelperTest {
             // Finally, last attempt should work.
             testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
             obs.assertComplete().assertValue(5);
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    @DisplayName("Should retry exponentially Single and finally success after 2 retries")
-    void shouldExponentiallyRetrySingle() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Integer> obs = Single
-                .<Integer>create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt < 3) {
-                        emitter.onError(new RuntimeException());
-                    } else {
-                        emitter.onSuccess(cpt);
-                    }
-                })
-                .compose(RxHelper.retryExponentialBackoffSingle(10, TimeUnit.SECONDS))
-                .test();
-
-            // First retry should wait 10sec
-            obs.assertNotComplete().assertNoValues();
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            // Second retry should wait 20sec
-            obs.assertNotComplete().assertNoValues();
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertComplete().assertValueAt(0, value -> value.equals(3));
         } finally {
             RxJavaPlugins.reset();
         }
@@ -590,6 +482,82 @@ class RxHelperTest {
             // on the third exception, which is a NonRetryableException, flow should be in error
             testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
             obs.assertError(NonRetryableException.class);
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    @DisplayName("Should retry exponentially and finally success after 2 retries")
+    void shouldExponentiallyRetry() {
+        try {
+            final TestScheduler testScheduler = new TestScheduler();
+            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+            AtomicInteger atomicCpt = new AtomicInteger(0);
+            @NonNull
+            TestSubscriber<Object> obs = Flowable
+                .generate(emitter -> {
+                    int cpt = atomicCpt.incrementAndGet();
+                    if (cpt <= 2) {
+                        emitter.onError(new RuntimeException());
+                    } else if (cpt <= 4) {
+                        emitter.onNext(cpt);
+                    } else {
+                        emitter.onComplete();
+                    }
+                })
+                .retryWhen(RxHelper.retryExponentialBackoff(10, TimeUnit.SECONDS))
+                .test()
+                .assertNotComplete()
+                .assertNoValues();
+
+            // an exception has been thrown, so try to retry after ten seconds
+            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+            obs.assertNotComplete().assertNoValues();
+
+            // Second retry should take longer than first one as factor equals 2
+            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+            obs.assertNotComplete().assertNoValues();
+
+            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+            obs.assertComplete().assertValueAt(0, value -> value.equals(3)).assertValueAt(1, value -> value.equals(4));
+        } finally {
+            RxJavaPlugins.reset();
+        }
+    }
+
+    @Test
+    @DisplayName("Should not retry exponentially according to filter predicate ")
+    void shouldNotExponentiallyRetryFlowable() {
+        try {
+            final TestScheduler testScheduler = new TestScheduler();
+            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+            AtomicInteger atomicCpt = new AtomicInteger(0);
+            @NonNull
+            TestSubscriber<Object> obs = Flowable
+                .generate(emitter -> {
+                    int cpt = atomicCpt.incrementAndGet();
+                    if (cpt <= 2) {
+                        emitter.onError(new RuntimeException());
+                    } else if (cpt == 3) {
+                        emitter.onError(new NonRetryableException());
+                    } else if (cpt == 4) {
+                        emitter.onNext(cpt);
+                    } else {
+                        emitter.onComplete();
+                    }
+                })
+                .retryWhen(RxHelper.retryExponentialBackoff(10, 10, TimeUnit.SECONDS, 2, t -> !(t instanceof NonRetryableException)))
+                .test()
+                .assertNotComplete()
+                .assertNoValues();
+
+            // a retryable exception has been thrown twice
+            testScheduler.advanceTimeBy(20, TimeUnit.SECONDS);
+            // an non-retryable exception has been thrown, flow should be in error immediately
+            obs.assertError(NonRetryableException.class).assertNoValues();
         } finally {
             RxJavaPlugins.reset();
         }


### PR DESCRIPTION
**Description**

Add a predicate for expo retry backoff.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.2.0-add-retry-expo-predicate-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/4.2.0-add-retry-expo-predicate-SNAPSHOT/gravitee-common-4.2.0-add-retry-expo-predicate-SNAPSHOT.zip)
  <!-- Version placeholder end -->
