### PR TITLE
feat: add SizeUtils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.common</groupId>
     <artifactId>gravitee-common</artifactId>
-    <version>4.2.0</version>
+    <version>4.3.0-feat-add-size-utils-SNAPSHOT</version>
 
     <name>Gravitee.io APIM - Common</name>
 

--- a/src/main/java/io/gravitee/common/utils/SizeUtils.java
+++ b/src/main/java/io/gravitee/common/utils/SizeUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.utils;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SizeUtils {
+
+    /**
+     * Convert a size defined as a string such as '10KB', '10MB', '10GB' or '10B' or just '10' into integer byte value.
+     * For backward compatibility, we are considering that default unit is MB.
+     *
+     * @param stringValue size, can be a simple number (considered as MB) or a string containing value and unit like `20KB`.
+     *
+     * @return the value converted in bytes as a long or -1 if specified value is <code>null</code> (meaning infinite value).
+     * @throws NumberFormatException in case the specified value cannot be converted.
+     */
+    public static long toBytes(String stringValue) throws NumberFormatException {
+        long valueBytes = -1;
+        if (stringValue != null) {
+            try {
+                int value = Integer.parseInt(stringValue);
+                if (value >= 0) {
+                    // By default, consider MB
+                    valueBytes = Integer.parseInt(stringValue) * (1024 * 1024);
+                }
+            } catch (NumberFormatException nfe) {
+                stringValue = stringValue.toUpperCase();
+
+                try {
+                    if (stringValue.endsWith("G") || stringValue.endsWith("GB")) {
+                        long value = Long.parseLong(stringValue.substring(0, stringValue.indexOf('G')));
+                        valueBytes = value * (1024 * 1024 * 1024);
+                    } else if (stringValue.endsWith("MB") || stringValue.endsWith("M")) {
+                        long value = Long.parseLong(stringValue.substring(0, stringValue.indexOf('M')));
+                        valueBytes = value * (1024 * 1024);
+                    } else if (stringValue.endsWith("KB") || stringValue.endsWith("K")) {
+                        long value = Long.parseLong(stringValue.substring(0, stringValue.indexOf('K')));
+                        valueBytes = value * (1024);
+                    } else if (stringValue.endsWith("B")) {
+                        valueBytes = Long.parseLong(stringValue.substring(0, stringValue.indexOf('B')));
+                    } else {
+                        throw nfe;
+                    }
+                } catch (NumberFormatException nfe2) {
+                    throw nfe;
+                }
+            }
+        }
+
+        return valueBytes;
+    }
+}

--- a/src/test/java/io/gravitee/common/utils/SizeUtilsTest.java
+++ b/src/test/java/io/gravitee/common/utils/SizeUtilsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+class SizeUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource(
+        value = {
+            "128B, 128",
+            "128K, 131072",
+            "128KB, 131072",
+            "128, 134217728",
+            "128M, 134217728",
+            "128MB, 134217728",
+            "128G, 137438953472",
+            "128GB, 137438953472",
+        }
+    )
+    void should_convert_string_value_to_integer_byte_value(String stringValue, Long expectedValue) {
+        final long bytes = SizeUtils.toBytes(stringValue);
+        assertThat(bytes).withFailMessage("Expected %s for %s, got %s", expectedValue, stringValue, bytes).isEqualTo(expectedValue);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { "invalid", "128FooBar" })
+    void should_throw_number_format_exception_when_invalid(String stringValue) {
+        assertThrows(NumberFormatException.class, () -> SizeUtils.toBytes(stringValue));
+    }
+
+    @Test
+    void should_return_minus_1_when_null() {
+        assertThat(SizeUtils.toBytes(null)).isEqualTo(-1);
+    }
+}


### PR DESCRIPTION
**Description**

This is an extract of a conversion algorithm that can be found at several location in APIM (at least [here](https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/core/logging/LoggingContext.java#L101) and [here](https://github.com/gravitee-io/gravitee-api-management/blob/master/gravitee-apim-gateway/gravitee-apim-gateway-core/src/main/java/io/gravitee/gateway/reactive/core/v4/analytics/LoggingContext.java#L106)).
This avoids duplication and facilitates reusability.

Once approved and merged, a PR will be opened on APIM.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.3.0-feat-add-size-utils-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/4.3.0-feat-add-size-utils-SNAPSHOT/gravitee-common-4.3.0-feat-add-size-utils-SNAPSHOT.zip)
  <!-- Version placeholder end -->
