### PR TITLE
fix: make lombok dependency provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,8 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <!-- Templating -->


### PR DESCRIPTION
**Description**

Lombok should not be in scope `compile` but `provided`.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.3.1-fix-remove-lombok-compile-dependency-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/4.3.1-fix-remove-lombok-compile-dependency-SNAPSHOT/gravitee-common-4.3.1-fix-remove-lombok-compile-dependency-SNAPSHOT.zip)
  <!-- Version placeholder end -->
