### PR TITLE
feat: add unsubscribe method for EventManager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <nimbus-jose-jwt.version>9.15.2</nimbus-jose-jwt.version>
         <freemarker.version>2.3.31</freemarker.version>
         <gravitee-gateway-api.version>3.5.0</gravitee-gateway-api.version>
+        <awaitability.version>4.2.1</awaitability.version>
     </properties>
 
     <dependencyManagement>
@@ -164,6 +165,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitability.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/common/event/Event.java
+++ b/src/main/java/io/gravitee/common/event/Event.java
@@ -18,7 +18,7 @@ package io.gravitee.common.event;
 /**
  * @author David BRASSELY (brasseld at gmail.com)
  */
-public interface Event<T extends Enum, S> {
+public interface Event<T extends Enum<T>, S> {
     S content();
 
     T type();

--- a/src/main/java/io/gravitee/common/event/EventManager.java
+++ b/src/main/java/io/gravitee/common/event/EventManager.java
@@ -19,11 +19,15 @@ package io.gravitee.common.event;
  * @author David BRASSELY (brasseld at gmail.com)
  */
 public interface EventManager {
-    void publishEvent(Enum type, Object content);
+    <T extends Enum<T>, S> void publishEvent(final T type, final S content);
 
-    void publishEvent(Event event);
+    <T extends Enum<T>, S> void publishEvent(final Event<T, S> event);
 
-    <T extends Enum> void subscribeForEvents(EventListener<T, ?> eventListener, Class<T> events);
+    <T extends Enum<T>> void subscribeForEvents(final EventListener<T, ?> eventListener, final Class<T> eventTypeClass);
 
-    <T extends Enum> void subscribeForEvents(EventListener<T, ?> eventListener, T... events);
+    <T extends Enum<T>> void subscribeForEvents(final EventListener<T, ?> eventListener, final T... eventTypes);
+
+    <T extends Enum<T>> void unsubscribeForEvents(final EventListener<T, ?> eventListener, final Class<T> eventTypesClass);
+
+    <T extends Enum<T>> void unsubscribeForEvents(final EventListener<T, ?> eventListener, final T... eventTypes);
 }

--- a/src/main/java/io/gravitee/common/event/impl/SimpleEvent.java
+++ b/src/main/java/io/gravitee/common/event/impl/SimpleEvent.java
@@ -20,23 +20,4 @@ import io.gravitee.common.event.Event;
 /**
  * @author David BRASSELY (brasseld at gmail.com)
  */
-public class SimpleEvent<T extends Enum, S> implements Event<T, S> {
-
-    private final T type;
-    private final S content;
-
-    public SimpleEvent(T type, S content) {
-        this.type = type;
-        this.content = content;
-    }
-
-    @Override
-    public S content() {
-        return this.content;
-    }
-
-    @Override
-    public T type() {
-        return this.type;
-    }
-}
+public record SimpleEvent<T extends Enum<T>, S>(T type, S content) implements Event<T, S> {}

--- a/src/test/java/io/gravitee/common/event/SampleEvent.java
+++ b/src/test/java/io/gravitee/common/event/SampleEvent.java
@@ -16,8 +16,6 @@
 package io.gravitee.common.event;
 
 /**
- * @author David BRASSELY (brasseld at gmail.com)
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  */
-public interface EventListener<T extends Enum<T>, S> {
-    void onEvent(Event<T, S> event);
-}
+public record SampleEvent(SampleEventType type, String content) implements Event<SampleEventType, String> {}

--- a/src/test/java/io/gravitee/common/event/SampleEventType.java
+++ b/src/test/java/io/gravitee/common/event/SampleEventType.java
@@ -16,8 +16,10 @@
 package io.gravitee.common.event;
 
 /**
- * @author David BRASSELY (brasseld at gmail.com)
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
  */
-public interface EventListener<T extends Enum<T>, S> {
-    void onEvent(Event<T, S> event);
+public enum SampleEventType {
+    DEPLOY,
+    UNDEPLOY,
 }

--- a/src/test/java/io/gravitee/common/event/impl/EventManagerImplTest.java
+++ b/src/test/java/io/gravitee/common/event/impl/EventManagerImplTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.common.event.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.gravitee.common.event.EventListener;
+import io.gravitee.common.event.SampleEventType;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class EventManagerImplTest {
+
+    private EventManagerImpl cut;
+
+    @BeforeEach
+    public void beforeEach() {
+        cut = new EventManagerImpl();
+    }
+
+    @Nested
+    class SubscribeEventsTest {
+
+        @Test
+        void should_receive_any_event_when_subscribing_to_event_type_class() {
+            Set<String> contentReceived = new HashSet<>();
+            cut.subscribeForEvents(
+                (EventListener<SampleEventType, String>) event -> contentReceived.add(event.content()),
+                SampleEventType.class
+            );
+
+            cut.publishEvent(SampleEventType.DEPLOY, "value1");
+            cut.publishEvent(SampleEventType.UNDEPLOY, "value2");
+
+            await()
+                .atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(contentReceived).hasSize(2);
+                    assertThat(contentReceived).containsOnly("value1", "value2");
+                });
+        }
+
+        @Test
+        void should_receive_event_with_only_subscribe_event_type_when_subscribing_to_one_event_type() {
+            Set<String> contentReceived = new HashSet<>();
+            cut.subscribeForEvents(
+                (EventListener<SampleEventType, String>) event -> contentReceived.add(event.content()),
+                SampleEventType.DEPLOY
+            );
+
+            cut.publishEvent(SampleEventType.DEPLOY, "value1");
+            cut.publishEvent(SampleEventType.UNDEPLOY, "value2");
+
+            await()
+                .atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(contentReceived).hasSize(1);
+                    assertThat(contentReceived).containsOnly("value1");
+                });
+        }
+    }
+
+    @Nested
+    class UnsubscribeEventsTest {
+
+        @Test
+        void should_not_receive_any_event_after_subscribing_with_event_type_class_and_unsubscribing_with_event_type_class() {
+            Set<String> contentReceived = new HashSet<>();
+            EventListener<SampleEventType, String> eventListener = event -> contentReceived.add(event.content());
+            cut.subscribeForEvents(eventListener, SampleEventType.class);
+            cut.unsubscribeForEvents(eventListener, SampleEventType.class);
+            cut.publishEvent(SampleEventType.DEPLOY, "value1");
+
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> assertThat(contentReceived).isEmpty());
+        }
+
+        @Test
+        void should_not_receive_any_event_after_subscribing_with_event_type_class_and_unsubscribing_with_event_type() {
+            Set<String> contentReceived = new HashSet<>();
+            EventListener<SampleEventType, String> eventListener = event -> contentReceived.add(event.content());
+            cut.subscribeForEvents(eventListener, SampleEventType.class);
+            cut.unsubscribeForEvents(eventListener, SampleEventType.DEPLOY);
+            cut.publishEvent(SampleEventType.DEPLOY, "value1");
+            cut.publishEvent(SampleEventType.UNDEPLOY, "value2");
+
+            await()
+                .atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(contentReceived).hasSize(1);
+                    assertThat(contentReceived).containsOnly("value2");
+                });
+        }
+
+        @Test
+        void should_not_receive_any_event_after_subscribing_with_event_type_and_unsubscribing_with_event_type_class() {
+            Set<String> contentReceived = new HashSet<>();
+            EventListener<SampleEventType, String> eventListener = event -> contentReceived.add(event.content());
+            cut.subscribeForEvents(eventListener, SampleEventType.DEPLOY);
+            cut.unsubscribeForEvents(eventListener, SampleEventType.class);
+            cut.publishEvent(SampleEventType.DEPLOY, "value1");
+
+            await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> assertThat(contentReceived).isEmpty());
+        }
+
+        @Test
+        void should_not_receive_any_event_after_subscribing_with_event_type_and_unsubscribing_with_event_type() {
+            Set<String> contentReceived = new HashSet<>();
+            EventListener<SampleEventType, String> eventListener = event -> contentReceived.add(event.content());
+            cut.subscribeForEvents(eventListener, SampleEventType.DEPLOY, SampleEventType.UNDEPLOY);
+            cut.unsubscribeForEvents(eventListener, SampleEventType.DEPLOY);
+            cut.publishEvent(SampleEventType.DEPLOY, "value1");
+            cut.publishEvent(SampleEventType.UNDEPLOY, "value2");
+
+            await()
+                .atMost(30, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    assertThat(contentReceived).hasSize(1);
+                    assertThat(contentReceived).containsOnly("value2");
+                });
+        }
+    }
+}


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/CJ-1766

**Description**
In order to properly unregister event listener when undeploying api, EventManager required some improvements:

  - refactor EventManager to properly manage concurrency
  - fix an issue when subscribing to subset of EventType
  - add unsubscribe method to remove listener


**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.4.0-CJ-1766-improve-event-manager-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/4.4.0-CJ-1766-improve-event-manager-SNAPSHOT/gravitee-common-4.4.0-CJ-1766-improve-event-manager-SNAPSHOT.zip)
  <!-- Version placeholder end -->
