### PR TITLE
imp(Page): add map() method to simplify usage

### DIFF
--- a/src/main/java/io/gravitee/common/data/domain/Page.java
+++ b/src/main/java/io/gravitee/common/data/domain/Page.java
@@ -16,6 +16,7 @@
 package io.gravitee.common.data.domain;
 
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
@@ -33,6 +34,10 @@ public class Page<T> {
         this.page = page;
         this.size = size;
         this.total = total;
+    }
+
+    public <U> Page<? extends U> map(Function<? super T, ? extends U> mapper) {
+        return new Page<>(content.stream().map(mapper).toList(), page, size, total);
     }
 
     public List<T> getContent() {

--- a/src/main/java/io/gravitee/common/util/Maps.java
+++ b/src/main/java/io/gravitee/common/util/Maps.java
@@ -21,14 +21,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
+import lombok.experimental.UtilityClass;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
+@UtilityClass
 public class Maps {
-
-    private Maps() {}
 
     public static <K, V> MapBuilder<K, V> builder() {
         return builder(HashMap::new);


### PR DESCRIPTION
**Issue**

No issue associed

**Description**

add map() method on page to allow usage as

```java
Page<B> result = service.findAllA().map(A::toB);
// instead of
Page<A> firstResult = service.findAllA();
var intermediate = firstResult.getContent().stream.map(A::toB);
Page<B> result = new Page<>(intermediate, firstResult.getPageNumber(), (int) firstResult.getPageElements(), firstResult.getTotalElements());;
```
