### PR TITLE
fix: make get by list of string from EL

### DIFF
--- a/src/main/java/io/gravitee/common/util/TemplatedValueHashMap.java
+++ b/src/main/java/io/gravitee/common/util/TemplatedValueHashMap.java
@@ -16,6 +16,7 @@
 package io.gravitee.common.util;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -30,6 +31,10 @@ public class TemplatedValueHashMap extends HashMap<String, String> {
     @Override
     public String get(Object key) {
         String value;
+
+        if (key instanceof List<?> list && !list.isEmpty()) {
+            return (value = super.get(list.get(0))) == null ? null : resolve(value);
+        }
         return (value = super.get(key)) == null ? null : resolve(value);
     }
 

--- a/src/test/java/io/gravitee/common/util/TemplatedValueHashMapTest.java
+++ b/src/test/java/io/gravitee/common/util/TemplatedValueHashMapTest.java
@@ -15,8 +15,10 @@
  */
 package io.gravitee.common.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -25,44 +27,54 @@ import org.junit.jupiter.api.Test;
  * @author David BRASSELY (david at gravitee.io)
  * @author GraviteeSource Team
  */
-public class TemplatedValueHashMapTest {
+class TemplatedValueHashMapTest {
 
     @Test
-    public void should_returnNull() {
+    public void should_return_null() {
         Map<String, String> properties = new TemplatedValueHashMap();
 
-        Assertions.assertNull(properties.get("dummy_key"));
+        assertThat(properties.get("dummy_key")).isNull();
     }
 
     @Test
-    public void should_returnValue() {
+    public void should_return_value() {
         Map<String, String> properties = new TemplatedValueHashMap();
         properties.put("my_key", "my_value");
-        Assertions.assertEquals("my_value", properties.get("my_key"));
+        assertThat(properties.get("my_key")).isEqualTo("my_value");
     }
 
     @Test
-    public void should_returnResolveSingleValue() {
+    public void should_return_resolve_single_value() {
         Map<String, String> properties = new TemplatedValueHashMap();
         properties.put("my_key", "my_value");
         properties.put("other_key", "{{my_key}}");
-        Assertions.assertEquals("my_value", properties.get("other_key"));
+        assertThat(properties.get("other_key")).isEqualTo("my_value");
     }
 
     @Test
-    public void should_returnResolveMultipleValue() {
+    public void should_return_resolve_multiple_value() {
         Map<String, String> properties = new TemplatedValueHashMap();
         properties.put("my_key", "my_value");
         properties.put("my_key2", "other_value");
         properties.put("other_key", "{{my_key}} - {{my_key2}}");
-        Assertions.assertEquals("my_value - other_value", properties.get("other_key"));
+        assertThat(properties.get("other_key")).isEqualTo("my_value - other_value");
     }
 
     @Test
-    public void should_returnResolveUnknownValue() {
+    public void should_return_resolve_unknown_value() {
         Map<String, String> properties = new TemplatedValueHashMap();
         properties.put("my_key", "my_value");
         properties.put("other_key", "{{my_key2}}");
         assertThrows(IllegalStateException.class, () -> properties.get("other_key"));
+    }
+
+    @Test
+    public void should_return_resolve_value_with_list_key() {
+        Map<String, String> properties = new TemplatedValueHashMap();
+        properties.put("my_key", "my_value");
+        properties.put("my_key2", "my_value2");
+        properties.put("my_key3", "my_value3");
+
+        assertThat(properties.get(List.of("my_key2"))).isEqualTo("my_value2");
     }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-8819

**Description**

This PR addresses an issue when using a Spring EL expression to access an API property with a key derived from an HTTP request header, such as `{#properties[#request.header['test']]}`. The problem arises because API properties are indexed by a string key, whereas HTTP headers are multi-valued, meaning `#request.header['test']` returns a list of string values.

**Additional context**

In interpreted mode, Spring EL is able to detect that a string is expected and that a list of strings is provided, automatically extracting the first value. However, when the EL runs in compiled mode, used for performance optimization in V4 and V4 emulated mode, this behavior breaks completely. The reason it works in interpreted mode is that API properties are backed by `TemplatedValueHashMap`, which extends `HashMap<String, String>`. This allows Spring EL to infer the key type and perform the automatic conversion. If the API properties were backed directly by a generic `Map`, the generics information (key as String, value as String) would be lost, making this conversion impossible.

**Ideally, such expressions should be disallowed**, but they were unintentionally supported in V2, where ELs always ran in interpreted mode and never in compiled mode so we need to keep it backward compatible, unfortunately. The issue cannot be resolved within Spring EL itself because there is no way to control the AST compilation process. Instead, the proposed fix ensures that if the given key is a list instead of a string, the first element is extracted and used as the key, preserving functionality across both interpreted and compiled modes.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.6.1-apim-8819-fix-el-resolve-property-by-list-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/4.6.1-apim-8819-fix-el-resolve-property-by-list-SNAPSHOT/gravitee-common-4.6.1-apim-8819-fix-el-resolve-property-by-list-SNAPSHOT.zip)
  <!-- Version placeholder end -->
