### PR TITLE
feat: add retryLinear method

### DIFF
--- a/src/main/java/io/gravitee/common/utils/RxHelper.java
+++ b/src/main/java/io/gravitee/common/utils/RxHelper.java
@@ -64,8 +64,8 @@ public class RxHelper {
      * Returns a {@link FlowableTransformer} that can be used in a composition.
      * It applies an interval for each element received in the {@link Flowable} upstream in opposition to {@link Flowable#delay(long, TimeUnit)} which will apply the delay only once for the {@link Flowable}
      *
-     * @param delay    the delay to apply between each element of the {@link Flowable}
-     * @param timeUnit the {@link TimeUnit}  of the delay
+     * @param delay              the delay to apply between each element of the {@link Flowable}
+     * @param timeUnit           the {@link TimeUnit}  of the delay
      * @param skipDelayPredicate the predicate to test if delay should be skipped, else delay is applied
      * @return a {@link FlowableTransformer} that will be applied.
      */
@@ -97,9 +97,9 @@ public class RxHelper {
      * Returns a {@link FlowableTransformer} that can be used in a composition.
      * It retries the {@link Flowable} X times with delay between each attempt
      *
-     * @param times         the attempts number
-     * @param retryInterval the delay between each retry
-     * @param timeUnit      the {@link TimeUnit} of the retryInterval
+     * @param times          the attempts number
+     * @param retryInterval  the delay between each retry
+     * @param timeUnit       the {@link TimeUnit} of the retryInterval
      * @param retryPredicate the predicate to test if instance of {@link Throwable} has to be retried, else, emits directly the error
      * @return a {@link FlowableTransformer} that will be applied.
      */
@@ -134,10 +134,10 @@ public class RxHelper {
     /**
      * Same as {@link #retryFlowable(int, int, TimeUnit)} but with a {@link Maybe} instead.
      *
-     * @param times         the attempts number
-     * @param retryInterval the delay between each retry
-     * @param timeUnit      the {@link TimeUnit} of the retryInterval
-     * @param <R>           the value type.
+     * @param times          the attempts number
+     * @param retryInterval  the delay between each retry
+     * @param timeUnit       the {@link TimeUnit} of the retryInterval
+     * @param <R>            the value type.
      * @param retryPredicate the predicate to test if instance of {@link Throwable} has to be retried, else, emits directly the error
      * @return a {@link MaybeTransformer} that will be applied.
      */
@@ -171,10 +171,10 @@ public class RxHelper {
     /**
      * Same as {@link #retryMaybe(int, int, TimeUnit)} but with a {@link Single} instead.
      *
-     * @param times         the attempts number
-     * @param retryInterval the delay between each retry
-     * @param timeUnit      the {@link TimeUnit} of the retryInterval
-     * @param <R>           the value type.
+     * @param times          the attempts number
+     * @param retryInterval  the delay between each retry
+     * @param timeUnit       the {@link TimeUnit} of the retryInterval
+     * @param <R>            the value type.
      * @param retryPredicate the predicate to test if instance of {@link Throwable} has to be retried, else, emits directly the error
      * @return a {@link MaybeTransformer} that will be applied.
      */
@@ -201,10 +201,41 @@ public class RxHelper {
      * @param retryInterval the delay between each retry
      * @param timeUnit      the {@link TimeUnit} of the retryInterval
      * @return a {@link CompletableTransformer} that will be applied.
+     * @deprecated See {@link #retryCompletable(int, int, TimeUnit)}
      */
+    @Deprecated(forRemoval = true)
     public static CompletableTransformer retry(int times, int retryInterval, TimeUnit timeUnit) {
+        return retryCompletable(times, retryInterval, timeUnit, TRUE_PREDICATE);
+    }
+
+    /**
+     * Returns a {@link CompletableTransformer} that can be used in a composition.
+     * It retries the {@link Flowable} X times with delay between each attempt
+     *
+     * @param times          the attempts number
+     * @param retryInterval  the delay between each retry
+     * @param timeUnit       the {@link TimeUnit} of the retryInterval
+     * @param retryPredicate the predicate to test if instance of {@link Throwable} has to be retried, else, emits directly the error
+     * @return a {@link CompletableTransformer} that will be applied.
+     * @deprecated See {@link #retryCompletable(int, int, TimeUnit, Predicate)}
+     */
+    @Deprecated(forRemoval = true)
+    public static CompletableTransformer retry(int times, int retryInterval, TimeUnit timeUnit, Predicate<Throwable> retryPredicate) {
+        return retryCompletable(times, retryInterval, timeUnit, retryPredicate);
+    }
+
+    /**
+     * Returns a {@link CompletableTransformer} that can be used in a composition.
+     * It retries the {@link Flowable} X times with delay between each attempt
+     *
+     * @param times         the attempts number
+     * @param retryInterval the delay between each retry
+     * @param timeUnit      the {@link TimeUnit} of the retryInterval
+     * @return a {@link CompletableTransformer} that will be applied.
+     */
+    public static CompletableTransformer retryCompletable(int times, int retryInterval, TimeUnit timeUnit) {
         // By default, we want to retry every throwable
-        return retry(times, retryInterval, timeUnit, TRUE_PREDICATE);
+        return retryCompletable(times, retryInterval, timeUnit, TRUE_PREDICATE);
     }
 
     /**
@@ -217,7 +248,12 @@ public class RxHelper {
      * @param retryPredicate the predicate to test if instance of {@link Throwable} has to be retried, else, emits directly the error
      * @return a {@link CompletableTransformer} that will be applied.
      */
-    public static CompletableTransformer retry(int times, int retryInterval, TimeUnit timeUnit, Predicate<Throwable> retryPredicate) {
+    public static CompletableTransformer retryCompletable(
+        int times,
+        int retryInterval,
+        TimeUnit timeUnit,
+        Predicate<Throwable> retryPredicate
+    ) {
         Objects.requireNonNull(retryPredicate, RETRY_PREDICATE_IS_NULL_ERROR);
         // Negate the retryPredicate to skip the Throwable in operators
         final Predicate<Throwable> skipThrowable = retryPredicate.negate();
@@ -235,7 +271,7 @@ public class RxHelper {
      * Returns a {@link FlowableTransformer} that can be used in a composition.
      * It ignores the N first throwable then return the N+1 in error.
      *
-     * @param limit the number of throwables to ignore
+     * @param limit                  the number of throwables to ignore
      * @param throwDirectlyPredicate the predicate to check if limit should be computed or not. If it returns true, then {@link Maybe#error(Throwable)} is immediately emitted
      * @return a {@link FlowableTransformer} that will be applied.
      */
@@ -256,8 +292,8 @@ public class RxHelper {
      * It will progressively wait longer intervals between consecutive retries.
      * The initial delay is used as the beginning, then the factor of 2 is used to build the second delay without any max limitation.
      *
-     * @param initialDelay  the initial delay to wait
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay
+     * @param initialDelay the initial delay to wait
+     * @param timeUnit     the {@link TimeUnit} of the initialDelay
      * @return a {@link Function} that will be applied.
      */
     public static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
@@ -271,9 +307,9 @@ public class RxHelper {
      * It will progressively wait longer intervals between consecutive retries.
      * The initial delay is used as the beginning, then the factor of 2 is used to build the second delay until it reaches the maxDelay.
      *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
+     * @param initialDelay the initial delay to wait
+     * @param maxDelay     the max delay
+     * @param timeUnit     the {@link TimeUnit} of the initialDelay and maxDelay
      * @return a {@link Function} that will be applied.
      */
     public static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
@@ -288,10 +324,10 @@ public class RxHelper {
      * It will progressively wait longer intervals between consecutive retries.
      * The initial delay is used as the beginning, then the factor is used to build the second delay until it reaches the maxDelay.
      *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
-     * @param factor        factor used to compute next delay
+     * @param initialDelay the initial delay to wait
+     * @param maxDelay     the max delay
+     * @param timeUnit     the {@link TimeUnit} of the initialDelay and maxDelay
+     * @param factor       factor used to compute next delay
      * @return a {@link Function} that will be applied.
      */
     public static Function<? super Flowable<Throwable>, ? extends Publisher<?>> retryExponentialBackoff(
@@ -307,10 +343,10 @@ public class RxHelper {
      * It will progressively wait longer intervals between consecutive retries.
      * The initial delay is used as the beginning, then the factor is used to build the second delay until it reaches the maxDelay.
      *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
-     * @param factor        factor used to compute next delay
+     * @param initialDelay   the initial delay to wait
+     * @param maxDelay       the max delay
+     * @param timeUnit       the {@link TimeUnit} of the initialDelay and maxDelay
+     * @param factor         factor used to compute next delay
      * @param retryPredicate the predicate to test if instance of {@link Throwable} has to be retried, else, emits directly the error
      * @return a {@link Function} that will be applied.
      */
@@ -328,11 +364,11 @@ public class RxHelper {
      * It will progressively wait longer intervals between consecutive retries.
      * The initial delay is used as the beginning, then the factor is used to build the second delay until it reaches the maxDelay and maxAttempt
      *
-     * @param initialDelay  the initial delay to wait
-     * @param maxDelay      the max delay
-     * @param timeUnit      the {@link TimeUnit} of the initialDelay and maxDelay
-     * @param factor        factor used to compute next delay
-     * @param maxAttempt        maxAttempt max number of attempt
+     * @param initialDelay   the initial delay to wait
+     * @param maxDelay       the max delay
+     * @param timeUnit       the {@link TimeUnit} of the initialDelay and maxDelay
+     * @param factor         factor used to compute next delay
+     * @param maxAttempt     maxAttempt max number of attempt
      * @param retryPredicate the predicate to test if instance of {@link Throwable} has to be retried, else, emits directly the error
      * @return a {@link Function} that will be applied.
      */

--- a/src/test/java/io/gravitee/common/utils/RxHelperTest.java
+++ b/src/test/java/io/gravitee/common/utils/RxHelperTest.java
@@ -374,7 +374,7 @@ class RxHelperTest {
                             emitter.onComplete();
                         }
                     })
-                    .compose(RxHelper.retry(5, 10, TimeUnit.SECONDS))
+                    .compose(RxHelper.retryCompletable(5, 10, TimeUnit.SECONDS))
                     .test()
                     .assertNotComplete()
                     .assertNoValues();
@@ -408,7 +408,7 @@ class RxHelperTest {
                             emitter.onComplete();
                         }
                     })
-                    .compose(RxHelper.retry(2, 10, TimeUnit.SECONDS))
+                    .compose(RxHelper.retryCompletable(2, 10, TimeUnit.SECONDS))
                     .test()
                     .assertNotComplete()
                     .assertNoValues();
@@ -446,7 +446,7 @@ class RxHelperTest {
                             emitter.onComplete();
                         }
                     })
-                    .compose(RxHelper.retry(2, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
+                    .compose(RxHelper.retryCompletable(2, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
                     .test()
                     .assertNotComplete()
                     .assertNoValues();
@@ -477,7 +477,7 @@ class RxHelperTest {
                             emitter.onComplete();
                         }
                     })
-                    .compose(RxHelper.retry(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
+                    .compose(RxHelper.retryCompletable(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
                     .test()
                     .assertNotComplete()
                     .assertNoValues();

--- a/src/test/java/io/gravitee/common/utils/RxHelperTest.java
+++ b/src/test/java/io/gravitee/common/utils/RxHelperTest.java
@@ -27,13 +27,16 @@ import io.reactivex.rxjava3.subscribers.TestSubscriber;
 import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 class RxHelperTest {
 
     @Test
@@ -41,546 +44,556 @@ class RxHelperTest {
         Flowable.interval(10000, TimeUnit.MILLISECONDS).compose(RxHelper.mergeWithFirst(Flowable.empty())).test().assertComplete();
     }
 
-    @Test
-    @DisplayName("Should delay element of Flowable by 10 seconds")
-    void shouldDelayElement() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+    @Nested
+    class DelayElement {
 
-            final RuntimeException exception = new RuntimeException();
-            final TestSubscriber<Serializable> obs = Flowable
-                .fromArray(exception, "attempt1", 12)
-                .compose(RxHelper.delayElement(10, TimeUnit.SECONDS))
-                .test()
-                .assertNotComplete();
+        @Test
+        void should_delay_element_of_Flowable_by_10_seconds() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
 
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertValueAt(0, value -> value.equals(exception));
+                final RuntimeException exception = new RuntimeException();
+                final TestSubscriber<Serializable> obs = Flowable
+                    .fromArray(exception, "attempt1", 12)
+                    .compose(RxHelper.delayElement(10, TimeUnit.SECONDS))
+                    .test()
+                    .assertNotComplete();
 
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertValueAt(0, value -> value.equals(exception)).assertValueAt(1, value -> value.equals("attempt1"));
-
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs
-                .assertComplete()
-                .assertValueAt(0, value -> value.equals(exception))
-                .assertValueAt(1, value -> value.equals("attempt1"))
-                .assertValueAt(2, value -> value.equals(12));
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    @DisplayName("Should delay element of Flowable by 10 seconds according to predicate")
-    void shouldDelayElementAccordingPredicate() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            final RuntimeException exception = new RuntimeException();
-            final TestSubscriber<Serializable> obs = Flowable
-                .fromArray(exception, "attempt1", "notDelayed", 12, "notDelayed")
-                .compose(RxHelper.delayElement(10, TimeUnit.SECONDS, o -> o == "notDelayed"))
-                .test()
-                .assertNotComplete();
-
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertValueAt(0, value -> value.equals(exception));
-
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs
-                .assertNotComplete()
-                .assertValueAt(0, value -> value.equals(exception))
-                .assertValueAt(1, value -> value.equals("attempt1"))
-                .assertValueAt(2, value -> value.equals("notDelayed"));
-
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs
-                .assertComplete()
-                .assertValueAt(0, value -> value.equals(exception))
-                .assertValueAt(1, value -> value.equals("attempt1"))
-                .assertValueAt(2, value -> value.equals("notDelayed"))
-                .assertValueAt(3, value -> value.equals(12))
-                .assertValueAt(4, value -> value.equals("notDelayed"));
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    @DisplayName("Should retry Flowable and success when attempted less than the limit")
-    void shouldRetryFlowable() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestSubscriber<Object> obs = Flowable
-                .generate(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 2) {
-                        emitter.onError(new RuntimeException());
-                    } else if (cpt <= 4) {
-                        emitter.onNext(cpt);
-                    } else {
-                        emitter.onComplete();
-                    }
-                })
-                .compose(RxHelper.retryFlowable(5, 10, TimeUnit.SECONDS))
-                .test()
-                //                          .awaitCount(4)
-                .assertNotComplete()
-                .assertNoValues();
-
-            // an exception has been thrown, so try to retry after ten seconds
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoValues();
-
-            // both exception has been thrown, values emit normally
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertComplete().assertValueAt(0, value -> value.equals(3)).assertValueAt(1, value -> value.equals(4));
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    @DisplayName("Should not retry Flowable according to filter predicate")
-    void shouldNotRetryFlowableAccordingToPredicate() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestSubscriber<Object> obs = Flowable
-                .generate(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 2) {
-                        emitter.onError(new NonRetryableException());
-                    } else {
-                        emitter.onComplete();
-                    }
-                })
-                .compose(RxHelper.retryFlowable(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
-
-            // an exception has been thrown, flow should be in error immediately
-            obs.assertError(NonRetryableException.class).assertNoValues();
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    @DisplayName("Should retry Maybe and success when attempted less than the limit")
-    void shouldRetryMaybe() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Integer> obs = Maybe
-                .<Integer>create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt < 5) {
-                        emitter.onError(new RuntimeException());
-                    } else {
-                        emitter.onSuccess(cpt);
-                    }
-                })
-                .compose(RxHelper.retryMaybe(5, 10, TimeUnit.SECONDS))
-                .test();
-
-            for (int i = 0; i < 4; i++) {
-                // 4 errors are expected before a success.
-                obs.assertNotComplete().assertNoValues();
                 testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            }
+                obs.assertNotComplete().assertValueAt(0, value -> value.equals(exception));
 
-            // Finally, last attempt should work.
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertComplete().assertValue(5);
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    @DisplayName("Should not retry Maybe according to retry predicate")
-    void shouldNotRetryMaybeAccordingToPredicate() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Integer> obs = Maybe
-                .<Integer>create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt < 5) {
-                        emitter.onError(new NonRetryableException());
-                    } else {
-                        emitter.onSuccess(cpt);
-                    }
-                })
-                .compose(RxHelper.retryMaybe(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
-                .test();
-
-            // an exception has been thrown, flow should be in error immediately
-            obs.assertError(NonRetryableException.class).assertNoValues();
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    @DisplayName("Should retry Single and success when attempted less than the limit")
-    void shouldRetrySingle() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Integer> obs = Single
-                .<Integer>create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt < 5) {
-                        emitter.onError(new RuntimeException());
-                    } else {
-                        emitter.onSuccess(cpt);
-                    }
-                })
-                .compose(RxHelper.retrySingle(5, 10, TimeUnit.SECONDS))
-                .test();
-
-            for (int i = 0; i < 4; i++) {
-                // 4 errors are expected before a success.
-                obs.assertNotComplete().assertNoValues();
                 testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs
+                    .assertNotComplete()
+                    .assertValueAt(0, value -> value.equals(exception))
+                    .assertValueAt(1, value -> value.equals("attempt1"));
+
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs
+                    .assertComplete()
+                    .assertValueAt(0, value -> value.equals(exception))
+                    .assertValueAt(1, value -> value.equals("attempt1"))
+                    .assertValueAt(2, value -> value.equals(12));
+            } finally {
+                RxJavaPlugins.reset();
             }
+        }
 
-            // Finally, last attempt should work.
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertComplete().assertValue(5);
-        } finally {
-            RxJavaPlugins.reset();
+        @Test
+        void should_delay_element_of_Flowable_by_10_seconds_according_to_predicate() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+                final RuntimeException exception = new RuntimeException();
+                final TestSubscriber<Serializable> obs = Flowable
+                    .fromArray(exception, "attempt1", "notDelayed", 12, "notDelayed")
+                    .compose(RxHelper.delayElement(10, TimeUnit.SECONDS, o -> o == "notDelayed"))
+                    .test()
+                    .assertNotComplete();
+
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertValueAt(0, value -> value.equals(exception));
+
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs
+                    .assertNotComplete()
+                    .assertValueAt(0, value -> value.equals(exception))
+                    .assertValueAt(1, value -> value.equals("attempt1"))
+                    .assertValueAt(2, value -> value.equals("notDelayed"));
+
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs
+                    .assertComplete()
+                    .assertValueAt(0, value -> value.equals(exception))
+                    .assertValueAt(1, value -> value.equals("attempt1"))
+                    .assertValueAt(2, value -> value.equals("notDelayed"))
+                    .assertValueAt(3, value -> value.equals(12))
+                    .assertValueAt(4, value -> value.equals("notDelayed"));
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
     }
 
-    @Test
-    @DisplayName("Should not retry Single according to retry predicate")
-    void shouldNotRetrySingleAccordingToPredicate() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+    @Nested
+    class RetryFlowable {
 
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Integer> obs = Single
-                .<Integer>create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt < 5) {
-                        emitter.onError(new NonRetryableException());
-                    } else {
-                        emitter.onSuccess(cpt);
-                    }
-                })
-                .compose(RxHelper.retrySingle(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
-                .test();
+        @Test
+        void should_retry_Flowable_and_success_when_attempted_less_than_the_limit() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
 
-            // an exception has been thrown, flow should be in error immediately
-            obs.assertError(NonRetryableException.class).assertNoValues();
-        } finally {
-            RxJavaPlugins.reset();
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestSubscriber<Object> obs = Flowable
+                    .generate(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt <= 2) {
+                            emitter.onError(new RuntimeException());
+                        } else if (cpt <= 4) {
+                            emitter.onNext(cpt);
+                        } else {
+                            emitter.onComplete();
+                        }
+                    })
+                    .compose(RxHelper.retryFlowable(5, 10, TimeUnit.SECONDS))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
+
+                // an exception has been thrown, so try to retry after ten seconds
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertNoValues();
+
+                // both exception has been thrown, values emit normally
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertComplete().assertValueAt(0, value -> value.equals(3)).assertValueAt(1, value -> value.equals(4));
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+
+        @Test
+        void should_not_retry_Flowable_according_to_predicate_filter() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestSubscriber<Object> obs = Flowable
+                    .generate(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt <= 2) {
+                            emitter.onError(new NonRetryableException());
+                        } else {
+                            emitter.onComplete();
+                        }
+                    })
+                    .compose(RxHelper.retryFlowable(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
+
+                // an exception has been thrown, flow should be in error immediately
+                obs.assertError(NonRetryableException.class).assertNoValues();
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+
+        @Test
+        void should_retry_Flowable_and_fail_when_attempted_more_than_the_limit_without_success() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestSubscriber<Object> obs = Flowable
+                    .generate(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt <= 3) {
+                            emitter.onError(new RuntimeException());
+                        } else {
+                            emitter.onComplete();
+                        }
+                    })
+                    .compose(RxHelper.retryFlowable(2, 10, TimeUnit.SECONDS))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
+
+                // an exception has been thrown, so try to retry after ten seconds
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertNoValues();
+
+                // two exception has been thrown, retry one more time
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertNoErrors().assertNoValues();
+
+                // on the third exception, flow should be in error
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertError(RuntimeException.class);
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
     }
 
-    @Test
-    @DisplayName("Should retry Flowable and fail when attempted more than the limit without success")
-    void shouldBeInErrorWhenExceedingRetryFlowableAttempts() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+    @Nested
+    class RetryMaybe {
 
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestSubscriber<Object> obs = Flowable
-                .generate(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 3) {
-                        emitter.onError(new RuntimeException());
-                    } else {
-                        emitter.onComplete();
-                    }
-                })
-                .compose(RxHelper.retryFlowable(2, 10, TimeUnit.SECONDS))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
+        @Test
+        void should_retry_Maybe_and_success_when_attempted_less_than_the_limit() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
 
-            // an exception has been thrown, so try to retry after ten seconds
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoValues();
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestObserver<Integer> obs = Maybe
+                    .<Integer>create(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt < 5) {
+                            emitter.onError(new RuntimeException());
+                        } else {
+                            emitter.onSuccess(cpt);
+                        }
+                    })
+                    .compose(RxHelper.retryMaybe(5, 10, TimeUnit.SECONDS))
+                    .test();
 
-            // two exception has been thrown, retry one more time
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoErrors().assertNoValues();
+                for (int i = 0; i < 4; i++) {
+                    // 4 errors are expected before a success.
+                    obs.assertNotComplete().assertNoValues();
+                    testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                }
 
-            // on the third exception, flow should be in error
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertError(RuntimeException.class);
-        } finally {
-            RxJavaPlugins.reset();
+                // Finally, last attempt should work.
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertComplete().assertValue(5);
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+
+        @Test
+        void should_not_retry_Maybe_according_to_retry_predicate() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestObserver<Integer> obs = Maybe
+                    .<Integer>create(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt < 5) {
+                            emitter.onError(new NonRetryableException());
+                        } else {
+                            emitter.onSuccess(cpt);
+                        }
+                    })
+                    .compose(RxHelper.retryMaybe(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
+                    .test();
+
+                // an exception has been thrown, flow should be in error immediately
+                obs.assertError(NonRetryableException.class).assertNoValues();
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
     }
 
-    @Test
-    @DisplayName("Should retry Completable and success when attempted less than the limit")
-    void shouldRetryCompletable() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+    @Nested
+    class RetrySingle {
 
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Void> obs = Completable
-                .create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 2) {
-                        emitter.onError(new RuntimeException());
-                    } else if (cpt <= 4) {
-                        emitter.onComplete();
-                    }
-                })
-                .compose(RxHelper.retry(5, 10, TimeUnit.SECONDS))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
+        @Test
+        void should_retry_Single_and_success_when_attempted_less_than_the_limit() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
 
-            // an exception has been thrown, so try to retry after ten seconds
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete();
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestObserver<Integer> obs = Single
+                    .<Integer>create(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt < 5) {
+                            emitter.onError(new RuntimeException());
+                        } else {
+                            emitter.onSuccess(cpt);
+                        }
+                    })
+                    .compose(RxHelper.retrySingle(5, 10, TimeUnit.SECONDS))
+                    .test();
 
-            // both exception has been thrown, values emit normally
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertComplete();
-        } finally {
-            RxJavaPlugins.reset();
+                for (int i = 0; i < 4; i++) {
+                    // 4 errors are expected before a success.
+                    obs.assertNotComplete().assertNoValues();
+                    testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                }
+
+                // Finally, last attempt should work.
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertComplete().assertValue(5);
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+
+        @Test
+        void should_not_retry_Single_according_to_retry_predicate() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestObserver<Integer> obs = Single
+                    .<Integer>create(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt < 5) {
+                            emitter.onError(new NonRetryableException());
+                        } else {
+                            emitter.onSuccess(cpt);
+                        }
+                    })
+                    .compose(RxHelper.retrySingle(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
+                    .test();
+
+                // an exception has been thrown, flow should be in error immediately
+                obs.assertError(NonRetryableException.class).assertNoValues();
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
     }
 
-    @Test
-    @DisplayName("Should retry Completable and fail when attempted more than the limit without success")
-    void shouldBeInErrorWhenExceedingRetryCompletableAttempts() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+    @Nested
+    class RetryCompletable {
 
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Void> obs = Completable
-                .create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 3) {
-                        emitter.onError(new RuntimeException());
-                    } else {
-                        emitter.onComplete();
-                    }
-                })
-                .compose(RxHelper.retry(2, 10, TimeUnit.SECONDS))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
+        @Test
+        void should_retry_Completable_and_success_when_attempted_less_than_the_limit() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
 
-            // an exception has been thrown, so try to retry after ten seconds
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoValues();
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestObserver<Void> obs = Completable
+                    .create(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt <= 2) {
+                            emitter.onError(new RuntimeException());
+                        } else if (cpt <= 4) {
+                            emitter.onComplete();
+                        }
+                    })
+                    .compose(RxHelper.retry(5, 10, TimeUnit.SECONDS))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
 
-            // two exception has been thrown, retry one more time
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoErrors().assertNoValues();
+                // an exception has been thrown, so try to retry after ten seconds
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete();
 
-            // on the third exception, flow should be in error
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertError(RuntimeException.class);
-        } finally {
-            RxJavaPlugins.reset();
+                // both exception has been thrown, values emit normally
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertComplete();
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+
+        @Test
+        void should_retry_Completable_and_fail_when_attempted_more_than_the_limit_without_success() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestObserver<Void> obs = Completable
+                    .create(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt <= 3) {
+                            emitter.onError(new RuntimeException());
+                        } else {
+                            emitter.onComplete();
+                        }
+                    })
+                    .compose(RxHelper.retry(2, 10, TimeUnit.SECONDS))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
+
+                // an exception has been thrown, so try to retry after ten seconds
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertNoValues();
+
+                // two exception has been thrown, retry one more time
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertNoErrors().assertNoValues();
+
+                // on the third exception, flow should be in error
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertError(RuntimeException.class);
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+
+        @Test
+        void should_not_retry_according_to_retry_predicate() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestObserver<Void> obs = Completable
+                    .create(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt <= 3) {
+                            emitter.onError(new NonRetryableException());
+                        } else {
+                            emitter.onComplete();
+                        }
+                    })
+                    .compose(RxHelper.retry(2, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
+
+                // an exception has been thrown, flow should be in error immediately
+                obs.assertError(NonRetryableException.class).assertNoValues();
+            } finally {
+                RxJavaPlugins.reset();
+            }
+        }
+
+        @Test
+        void should_retry_first_exceptions_and_break_on_NonRetryableException_according_to_retry_predicate() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestObserver<Void> obs = Completable
+                    .create(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt <= 3) {
+                            emitter.onError(new RuntimeException());
+                        } else if (cpt <= 5) {
+                            emitter.onError(new NonRetryableException());
+                        } else {
+                            emitter.onComplete();
+                        }
+                    })
+                    .compose(RxHelper.retry(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
+
+                // an exception has been thrown, so try to retry after ten seconds
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertNoValues();
+
+                // two exception has been thrown, retry one more time
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertNoErrors().assertNoValues();
+
+                // on the third exception, which is a NonRetryableException, flow should be in error
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertError(NonRetryableException.class);
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
     }
 
-    @Test
-    @DisplayName("Should not retry according to retry predicate")
-    void shouldNotRetryBecauseOfFilterPredicate() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+    @Nested
+    class RetryExponentialBackoff {
 
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Void> obs = Completable
-                .create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 3) {
-                        emitter.onError(new NonRetryableException());
-                    } else {
-                        emitter.onComplete();
-                    }
-                })
-                .compose(RxHelper.retry(2, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
+        @Test
+        void should_retry_exponentially_and_finally_success_after_2_retries() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
 
-            // an exception has been thrown, flow should be in error immediately
-            obs.assertError(NonRetryableException.class).assertNoValues();
-        } finally {
-            RxJavaPlugins.reset();
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestSubscriber<Object> obs = Flowable
+                    .generate(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt <= 2) {
+                            emitter.onError(new RuntimeException());
+                        } else if (cpt <= 4) {
+                            emitter.onNext(cpt);
+                        } else {
+                            emitter.onComplete();
+                        }
+                    })
+                    .retryWhen(RxHelper.retryExponentialBackoff(10, TimeUnit.SECONDS))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
+
+                // an exception has been thrown, so try to retry after ten seconds
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertNoValues();
+
+                // Second retry should take longer than first one as factor equals 2
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertNotComplete().assertNoValues();
+
+                testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
+                obs.assertComplete().assertValueAt(0, value -> value.equals(3)).assertValueAt(1, value -> value.equals(4));
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
-    }
 
-    @Test
-    @DisplayName("Should retry first exceptions and break on NonRetryableException according to retry predicate")
-    void shouldRetryFirstOnly() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+        @Test
+        void should_retry_and_finally_fail_after_3_retries() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
 
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestObserver<Void> obs = Completable
-                .create(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 3) {
-                        emitter.onError(new RuntimeException());
-                    } else if (cpt <= 5) {
-                        emitter.onError(new NonRetryableException());
-                    } else {
-                        emitter.onComplete();
-                    }
-                })
-                .compose(RxHelper.retry(5, 10, TimeUnit.SECONDS, t -> !(t instanceof NonRetryableException)))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
-
-            // an exception has been thrown, so try to retry after ten seconds
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoValues();
-
-            // two exception has been thrown, retry one more time
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoErrors().assertNoValues();
-
-            // on the third exception, which is a NonRetryableException, flow should be in error
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertError(NonRetryableException.class);
-        } finally {
-            RxJavaPlugins.reset();
+                @NonNull
+                TestSubscriber<Object> obs = Flowable
+                    .generate(emitter -> emitter.onError(new RuntimeException("will never work")))
+                    .retryWhen(RxHelper.retryExponentialBackoff(1, 1, TimeUnit.SECONDS, 1, 3, t -> true))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
+                testScheduler.advanceTimeBy(4, TimeUnit.SECONDS);
+                obs.assertError(err -> err.getMessage().equals("will never work"));
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
-    }
 
-    @Test
-    @DisplayName("Should retry exponentially and finally success after 2 retries")
-    void shouldExponentiallyRetry() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
+        @Test
+        void should_not_retry_exponentially_according_to_filter_predicate() {
+            try {
+                final TestScheduler testScheduler = new TestScheduler();
+                RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
 
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestSubscriber<Object> obs = Flowable
-                .generate(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 2) {
-                        emitter.onError(new RuntimeException());
-                    } else if (cpt <= 4) {
-                        emitter.onNext(cpt);
-                    } else {
-                        emitter.onComplete();
-                    }
-                })
-                .retryWhen(RxHelper.retryExponentialBackoff(10, TimeUnit.SECONDS))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
+                AtomicInteger atomicCpt = new AtomicInteger(0);
+                @NonNull
+                TestSubscriber<Object> obs = Flowable
+                    .generate(emitter -> {
+                        int cpt = atomicCpt.incrementAndGet();
+                        if (cpt <= 2) {
+                            emitter.onError(new RuntimeException());
+                        } else if (cpt == 3) {
+                            emitter.onError(new NonRetryableException());
+                        } else if (cpt == 4) {
+                            emitter.onNext(cpt);
+                        } else {
+                            emitter.onComplete();
+                        }
+                    })
+                    .retryWhen(RxHelper.retryExponentialBackoff(10, 10, TimeUnit.SECONDS, 2, t -> !(t instanceof NonRetryableException)))
+                    .test()
+                    .assertNotComplete()
+                    .assertNoValues();
 
-            // an exception has been thrown, so try to retry after ten seconds
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoValues();
-
-            // Second retry should take longer than first one as factor equals 2
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertNotComplete().assertNoValues();
-
-            testScheduler.advanceTimeBy(10, TimeUnit.SECONDS);
-            obs.assertComplete().assertValueAt(0, value -> value.equals(3)).assertValueAt(1, value -> value.equals(4));
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    @DisplayName("Should retry and finally fail after 3 retries")
-    void shouldRetryWithMaxAttempt() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            @NonNull
-            TestSubscriber<Object> obs = Flowable
-                .generate(emitter -> emitter.onError(new RuntimeException("will never work")))
-                .retryWhen(RxHelper.retryExponentialBackoff(1, 1, TimeUnit.SECONDS, 1, 3, t -> true))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
-            testScheduler.advanceTimeBy(4, TimeUnit.SECONDS);
-            obs.assertError(err -> err.getMessage().equals("will never work"));
-        } finally {
-            RxJavaPlugins.reset();
-        }
-    }
-
-    @Test
-    @DisplayName("Should not retry exponentially according to filter predicate ")
-    void shouldNotExponentiallyRetryFlowable() {
-        try {
-            final TestScheduler testScheduler = new TestScheduler();
-            RxJavaPlugins.setComputationSchedulerHandler(s -> testScheduler);
-
-            AtomicInteger atomicCpt = new AtomicInteger(0);
-            @NonNull
-            TestSubscriber<Object> obs = Flowable
-                .generate(emitter -> {
-                    int cpt = atomicCpt.incrementAndGet();
-                    if (cpt <= 2) {
-                        emitter.onError(new RuntimeException());
-                    } else if (cpt == 3) {
-                        emitter.onError(new NonRetryableException());
-                    } else if (cpt == 4) {
-                        emitter.onNext(cpt);
-                    } else {
-                        emitter.onComplete();
-                    }
-                })
-                .retryWhen(RxHelper.retryExponentialBackoff(10, 10, TimeUnit.SECONDS, 2, t -> !(t instanceof NonRetryableException)))
-                .test()
-                .assertNotComplete()
-                .assertNoValues();
-
-            // a retryable exception has been thrown twice
-            testScheduler.advanceTimeBy(20, TimeUnit.SECONDS);
-            // an non-retryable exception has been thrown, flow should be in error immediately
-            obs.assertError(NonRetryableException.class).assertNoValues();
-        } finally {
-            RxJavaPlugins.reset();
+                // a retryable exception has been thrown twice
+                testScheduler.advanceTimeBy(20, TimeUnit.SECONDS);
+                // an non-retryable exception has been thrown, flow should be in error immediately
+                obs.assertError(NonRetryableException.class).assertNoValues();
+            } finally {
+                RxJavaPlugins.reset();
+            }
         }
     }
 


### PR DESCRIPTION
**Description**

Rename `RxHelper.retry` for `RxHelper.retryCompletable`
Add a `retryLinear` that return the same type as `retryExponentialBackoff` so we can select the type of retry more easily

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.7.0-rxhelper-retry-rename-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/4.7.0-rxhelper-retry-rename-SNAPSHOT/gravitee-common-4.7.0-rxhelper-retry-rename-SNAPSHOT.zip)
  <!-- Version placeholder end -->
