### PR TITLE
fix: gravitee-parent version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.2.4</version>
+        <version>22.5.1</version>
     </parent>
 
     <groupId>io.gravitee.common</groupId>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/11066

With reference to this PR : https://github.com/gravitee-io/gravitee-common/pull/147

**Description**

CI/CD was failing for releasing new version, after approval and merge of #147.
link : https://app.circleci.com/pipelines/github/gravitee-io/gravitee-common/725/workflows/4750d18f-4480-4277-ad4a-599385976b58/jobs/3532

Got suggestion to update the  "gravitee-parent" version, which was not updated to the latest version. 
So updated the same in this PR

-------

Error :  Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.7.0:deploy failed: Nexus connection problem to URL [https://oss.sonatype.org/ ]: 401 - Unauthorized ->

----

**Additional context**

#147 behaviour is working as expected

<img width="1728" height="1055" alt="image" src="https://github.com/user-attachments/assets/0c5286f8-8386-4641-867f-5c4e30f54c43" />


<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->