### PR TITLE
fix: gravitee circleci version update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.12.1
+    gravitee: gravitee-io/gravitee@4.16.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)


### PR DESCRIPTION
**Issue**

Check getting failed for changes of [APIM-11066](https://gravitee.atlassian.net/browse/APIM-11066)

**Description**

In the main APIM PR, checks are failing due to an outdated CircleCI version in gravitee-common.
Since this repository is not updated frequently, it still contains older versions, which are now causing errors at later stages.

**Additional context**

<img width="1340" height="498" alt="image" src="https://github.com/user-attachments/assets/c08830fb-4b77-4ea0-b8ec-991fb793f356" />
link : https://github.com/gravitee-io/gravitee-api-management/pull/13307




[APIM-11066]: https://gravitee.atlassian.net/browse/APIM-11066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ