### PR TITLE
fix: add Private Network Access header constants (APIM-13215)

### DIFF
--- a/src/main/java/io/gravitee/common/http/HttpHeaders.java
+++ b/src/main/java/io/gravitee/common/http/HttpHeaders.java
@@ -84,6 +84,14 @@ public class HttpHeaders implements MultiValueMap<String, String> {
      */
     public static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
     /**
+     * See {@link <a href="https://wicg.github.io/private-network-access/#headers">Private Network Access specification</a>}.
+     */
+    public static final String ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK = "Access-Control-Request-Private-Network";
+    /**
+     * See {@link <a href="https://wicg.github.io/private-network-access/#headers">Private Network Access specification</a>}.
+     */
+    public static final String ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = "Access-Control-Allow-Private-Network";
+    /**
      * See {@link <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.6">HTTP/1.1 documentation</a>}.
      */
     public static final String AGE = "Age";


### PR DESCRIPTION
Cherry-pick of 62de7fb5 onto newly created `4.7.x` maintenance branch (forked from tag `4.7.3`) to enable backporting the APIM PNA CORS feature to APIM 4.8.x and 4.9.x (both consume gravitee-common 4.7.3 today).

## Summary
- Adds `Access-Control-Request-Private-Network` and `Access-Control-Allow-Private-Network` constants to `HttpHeaders`.
- Required by gravitee-api-management PRs #16671 (4.9.x) and #16672 (4.8.x), backports of #15957.

## Reference
- Jira: [APIM-13215](https://gravitee.atlassian.net/browse/APIM-13215)
- Original commit on master: gravitee-io/gravitee-common@62de7fb5
- Released as `4.9.1` on master line.

## Test plan
- [ ] CI green
- [ ] Resulting tag (`4.7.4`) consumed by APIM 4.8.x and 4.9.x backports

[APIM-13215]: https://gravitee.atlassian.net/browse/APIM-13215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.7.4-wbabyte-cherry-pick-pna-4-7-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/common/gravitee-common/4.7.4-wbabyte-cherry-pick-pna-4-7-x-SNAPSHOT/gravitee-common-4.7.4-wbabyte-cherry-pick-pna-4-7-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
