### PR TITLE
fix: add Private Network Access header constants (APIM-13215)

### DIFF
--- a/src/main/java/io/gravitee/common/http/HttpHeaders.java
+++ b/src/main/java/io/gravitee/common/http/HttpHeaders.java
@@ -84,6 +84,14 @@ public class HttpHeaders implements MultiValueMap<String, String> {
      */
     public static final String ACCESS_CONTROL_REQUEST_METHOD = "Access-Control-Request-Method";
     /**
+     * See {@link <a href="https://wicg.github.io/private-network-access/#headers">Private Network Access specification</a>}.
+     */
+    public static final String ACCESS_CONTROL_REQUEST_PRIVATE_NETWORK = "Access-Control-Request-Private-Network";
+    /**
+     * See {@link <a href="https://wicg.github.io/private-network-access/#headers">Private Network Access specification</a>}.
+     */
+    public static final String ACCESS_CONTROL_ALLOW_PRIVATE_NETWORK = "Access-Control-Allow-Private-Network";
+    /**
      * See {@link <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.6">HTTP/1.1 documentation</a>}.
      */
     public static final String AGE = "Age";


### PR DESCRIPTION
Cherry-pick of 62de7fb5 onto newly created `4.8.x` maintenance branch (forked from tag `4.8.0`) to enable backporting the APIM PNA CORS feature to APIM 4.10.x.

## Summary
- Adds `Access-Control-Request-Private-Network` and `Access-Control-Allow-Private-Network` constants to `HttpHeaders`.
- Required by gravitee-api-management PR #16670 (backport of #15957).

## Reference
- Jira: [APIM-13215](https://gravitee.atlassian.net/browse/APIM-13215)
- Original commit on master: gravitee-io/gravitee-common@62de7fb5
- Released as `4.9.1` on master line.

## Test plan
- [ ] CI green
- [ ] Resulting tag (`4.8.1`) consumed by APIM 4.10.x backport PR #16670

[APIM-13215]: https://gravitee.atlassian.net/browse/APIM-13215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ